### PR TITLE
Add search and search table endpoints

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,9 +25,9 @@ jobs:
           python3 -m pip install -U poetry
           poetry install
 
-      - name: Lint
-        run: |
-          export PIP_USER=0; poetry run pre-commit run --all-files
+#      - name: Lint
+#        run: |
+#          export PIP_USER=0; poetry run pre-commit run --all-files
 
       - name: Unit Tests
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,9 +25,9 @@ jobs:
           python3 -m pip install -U poetry
           poetry install
 
-#      - name: Lint
-#        run: |
-#          export PIP_USER=0; poetry run pre-commit run --all-files
+      - name: Lint
+        run: |
+          export PIP_USER=0; poetry run pre-commit run --all-files
 
       - name: Unit Tests
         run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -741,4 +741,4 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8a83a1ea75160bdada9e9f93fcfe71018ab6a98c7d8acb1ea7a6d766f3d1fa0f"
+content-hash = "9b8302b135826e3a2bd81247f8c4765b34dbd44049961ccb05aaa832ece6638f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xata"
-version = "0.1.3"
+version = "0.2.0"
 description = "Python client for Xata.io"
 authors = ["Xata <support@xata.io>"]
 license = "Apache-2.0"
@@ -14,10 +14,10 @@ python-dotenv = "^0.21.0"
 orjson = "^3.8.1"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.2.0"
-black = "^22.10.0"
+pytest = "^7.2.1"
+black = "^22.12.0"
 flake8 = "^5.0.4"
-pre-commit = "^2.20.0"
+pre-commit = "^2.21.0"
 isort = "^5.12.0"
 flake8-bugbear = "^22.10.27"
 flake8-annotations = "^2.9.1"

--- a/tests/integration-tests/client_test.py
+++ b/tests/integration-tests/client_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import random
 import string
 

--- a/tests/integration-tests/client_test.py
+++ b/tests/integration-tests/client_test.py
@@ -412,9 +412,8 @@ def test_search_table_with_no_hits(
 def test_search_table_errorcases(client: XataClient, demo_db: string, posts: list[str]):
     result = client.search_table("MissingTable", "hello")
     assert "message" in result
-    assert result['message'] == f"table [{demo_db}:main/MissingTable] not found"
+    assert result["message"] == f"table [{demo_db}:main/MissingTable] not found"
 
     with pytest.raises(BadRequestException) as exc:
         client.search_table("Posts", "invalid", {"i-am": "invalid"})
     assert exc is not None
-

--- a/tests/unit-tests/client_test.py
+++ b/tests/unit-tests/client_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import unittest
 

--- a/xata/client.py
+++ b/xata/client.py
@@ -567,7 +567,7 @@ class XataClient:
     def search(
         self,
         query: str,
-        params: dict = {},
+        query_params: dict = {},
         db_name: str = None,
         branch_name: str = None,
     ) -> Optional[dict]:
@@ -577,7 +577,7 @@ class XataClient:
 
         :meta public:
         :param query: search string
-        :param params: more granular search criteria, see API docs for options
+        :param query_params: more granular search criteria, see API docs for options
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
@@ -588,11 +588,11 @@ class XataClient:
         db_name, branch_name = self.db_and_branch_names_from_params(
             db_name, branch_name
         )
-        params["query"] = query.strip()
+        query_params["query"] = query.strip()
         result = self.post(
             f"/db/{db_name}:{branch_name}/search",
-            params=params,
-            expect_codes=[404],
+            json=query_params,
+            expect_codes=[400, 403, 404, 500],
         )
 
         if result.status_code == 400:

--- a/xata/client.py
+++ b/xata/client.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import os
 from typing import Literal, Optional
@@ -311,7 +312,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                     from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :param columns: A list of column names to return. If not provided, all columns are returned.
         :param filter: A filter expression to apply to the query.
         :param sort: A sort expression to apply to the query.
@@ -344,7 +345,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :param columns: A list of column names to return. If not provided, all columns are returned.
         :param filter: A filter expression to apply to the query.
         :param sort: A sort expression to apply to the query.
@@ -380,7 +381,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :return: A record as a dictionary or None if it doesn't exist.
         """
         db_name, branch_name = self.db_and_branch_names_from_params(
@@ -411,7 +412,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :return: The ID of the created record.
         """
 
@@ -450,7 +451,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :return: The ID of the created or updated record.
         """
         db_name, branch_name = self.db_and_branch_names_from_params(
@@ -479,7 +480,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :return: The ID of the created or updated record.
         """
         db_name, branch_name = self.db_and_branch_names_from_params(
@@ -512,7 +513,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :return: The updated record.
         """
         db_name, branch_name = self.db_and_branch_names_from_params(
@@ -547,7 +548,7 @@ class XataClient:
         :param db_name: The name of the database to query. If not provided, the database name
                         from the client obejct is used.
         :param branch_name: The name of the branch to query. If not provided, the branch name
-                            from the client obejct is used.
+                        from the client obejct is used.
         :return: The deleted record.
         """
         db_name, branch_name = self.db_and_branch_names_from_params(
@@ -561,4 +562,45 @@ class XataClient:
         )
         if result.status_code == 404:
             raise RecordNotFoundException(id)
+        return result.json()
+
+    def search(
+        self,
+        query: str,
+        params: dict = {},
+        db_name: str = None,
+        branch_name: str = None,
+    ) -> Optional[dict]:
+        """This endpoint performs full text search across an entire database branch.
+
+        API docs: https://xata.io/docs/api-reference/db/db_branch_name/search#free-text-search
+
+        :meta public:
+        :param query: search string
+        :param params: more granular search criteria, see API docs for options
+        :param db_name: The name of the database to query. If not provided, the database name
+                        from the client obejct is used.
+        :param branch_name: The name of the branch to query. If not provided, the branch name
+                        from the client obejct is used.
+
+        :return set of matching records
+        """
+        db_name, branch_name = self.db_and_branch_names_from_params(
+            db_name, branch_name
+        )
+        params["query"] = query.strip()
+        result = self.post(
+            f"/db/{db_name}:{branch_name}/search",
+            params=params,
+            expect_codes=[404],
+        )
+
+        if result.status_code == 400:
+            raise BadRequestException(result.status_code, result.json()["message"])
+        if result.status_code == 403:
+            raise UnauthorizedException()
+        if result.status_code == 404:
+            raise RecordNotFoundException(query)
+        if result.status_code >= 500:
+            raise Exception(result.json())
         return result.json()

--- a/xata/errors.py
+++ b/xata/errors.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+
 class UnauthorizedException(Exception):
     pass
 


### PR DESCRIPTION
This PR adds the `search` and `search_table` APIs to query the corresponding endpoint including the integration tests.

ref to meta issues https://github.com/xataio/xata-py/issues/1 checking one item of.