### PR TITLE
Telemetry Headers

### DIFF
--- a/tests/unit-tests/client_test.py
+++ b/tests/unit-tests/client_test.py
@@ -1,24 +1,17 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 import unittest
 
 import pytest
 
 from xata.client import XataClient
 
+PATTERNS_UUID4 = re.compile(r"^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$", re.IGNORECASE)
+
 
 class TestXataClient(unittest.TestCase):
-
-    """
-    'apiKey': self.api_key,
-    'location': self.api_key_location,
-    'workspaceId': self.workspace_id,
-    'region': self.region,
-    'dbName': self.db_name,
-    'branchName': self.branch_name,
-    """
-
     def test_init_api_key_with_params(self):
         api_key = "param_ABCDEF123456789"
 
@@ -73,3 +66,16 @@ class TestXataClient(unittest.TestCase):
 
         with pytest.raises(Exception):
             XataClient(db_url="db_url", workspace_id="ws_id", db_name="db_name")
+
+    def test_init_telemetry_headers(self):
+        api_key = "this-key-42"
+        client1 = XataClient(api_key=api_key, workspace_id="ws_id")
+        headers = client1.get_headers()
+
+        assert len(headers) == 3
+        assert "authorization" in headers
+        assert headers["authorization"] == f"Bearer {api_key}"
+        assert "x-xata-client-id" in headers
+        assert PATTERNS_UUID4.match(headers["x-xata-client-id"])
+        assert "x-xata-session-id" in headers
+        assert PATTERNS_UUID4.match(headers["x-xata-session-id"])

--- a/tests/unit-tests/client_test.py
+++ b/tests/unit-tests/client_test.py
@@ -9,6 +9,7 @@ import pytest
 from xata.client import XataClient
 
 PATTERNS_UUID4 = re.compile(r"^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$", re.IGNORECASE)
+PATTERNS_SDK_VERSION = re.compile(r"^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$")
 
 
 class TestXataClient(unittest.TestCase):
@@ -87,3 +88,11 @@ class TestXataClient(unittest.TestCase):
 
         assert headers1["x-xata-client-id"] != headers2["x-xata-client-id"]
         assert headers1["x-xata-session-id"] != headers2["x-xata-session-id"]
+
+    def test_sdk_version(self):
+        db_url = "https://py-sdk-unit-test-12345.eu-west-1.xata.sh/db/testopia-042"
+        client = XataClient(db_url=db_url)
+        cfg = client.get_config()
+
+        assert "version" in cfg
+        assert PATTERNS_SDK_VERSION.match(cfg["version"])

--- a/tests/unit-tests/client_test.py
+++ b/tests/unit-tests/client_test.py
@@ -6,7 +6,7 @@ import unittest
 
 import pytest
 
-from xata.client import XataClient
+from xata.client import XataClient, SDK_VERSION
 
 PATTERNS_UUID4 = re.compile(r"^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$", re.IGNORECASE)
 PATTERNS_SDK_VERSION = re.compile(r"^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$")
@@ -73,7 +73,7 @@ class TestXataClient(unittest.TestCase):
         client1 = XataClient(api_key=api_key, workspace_id="ws_id")
         headers1 = client1.get_headers()
 
-        assert len(headers1) == 3
+        assert len(headers1) == 4
         assert "authorization" in headers1
         assert headers1["authorization"] == f"Bearer {api_key}"
         assert "x-xata-client-id" in headers1
@@ -81,6 +81,8 @@ class TestXataClient(unittest.TestCase):
         assert "x-xata-session-id" in headers1
         assert PATTERNS_UUID4.match(headers1["x-xata-session-id"])
         assert headers1["x-xata-client-id"] != headers1["x-xata-session-id"]
+        assert "x-xata-agent" in headers1
+        assert headers1['x-xata-agent'] == f"client=PY_SDK;version={SDK_VERSION};"
 
         api_key = "this-key-42"
         client2 = XataClient(api_key=api_key, workspace_id="ws_id")
@@ -88,6 +90,7 @@ class TestXataClient(unittest.TestCase):
 
         assert headers1["x-xata-client-id"] != headers2["x-xata-client-id"]
         assert headers1["x-xata-session-id"] != headers2["x-xata-session-id"]
+        assert headers1['x-xata-agent'] == headers2['x-xata-agent']
 
     def test_sdk_version(self):
         db_url = "https://py-sdk-unit-test-12345.eu-west-1.xata.sh/db/testopia-042"
@@ -96,3 +99,4 @@ class TestXataClient(unittest.TestCase):
 
         assert "version" in cfg
         assert PATTERNS_SDK_VERSION.match(cfg["version"])
+        assert SDK_VERSION == cfg["version"]

--- a/tests/unit-tests/client_test.py
+++ b/tests/unit-tests/client_test.py
@@ -68,7 +68,16 @@ class TestXataClient(unittest.TestCase):
         with pytest.raises(Exception):
             XataClient(db_url="db_url", workspace_id="ws_id", db_name="db_name")
 
-    def test_init_telemetry_headers(self):
+    def test_sdk_version(self):
+        db_url = "https://py-sdk-unit-test-12345.eu-west-1.xata.sh/db/testopia-042"
+        client = XataClient(db_url=db_url)
+        cfg = client.get_config()
+
+        assert "version" in cfg
+        assert PATTERNS_SDK_VERSION.match(cfg["version"])
+        assert SDK_VERSION == cfg["version"]
+
+    def test_telemetry_headers(self):
         api_key = "this-key-42"
         client1 = XataClient(api_key=api_key, workspace_id="ws_id")
         headers1 = client1.get_headers()
@@ -91,12 +100,3 @@ class TestXataClient(unittest.TestCase):
         assert headers1["x-xata-client-id"] != headers2["x-xata-client-id"]
         assert headers1["x-xata-session-id"] != headers2["x-xata-session-id"]
         assert headers1['x-xata-agent'] == headers2['x-xata-agent']
-
-    def test_sdk_version(self):
-        db_url = "https://py-sdk-unit-test-12345.eu-west-1.xata.sh/db/testopia-042"
-        client = XataClient(db_url=db_url)
-        cfg = client.get_config()
-
-        assert "version" in cfg
-        assert PATTERNS_SDK_VERSION.match(cfg["version"])
-        assert SDK_VERSION == cfg["version"]

--- a/tests/unit-tests/client_test.py
+++ b/tests/unit-tests/client_test.py
@@ -70,12 +70,20 @@ class TestXataClient(unittest.TestCase):
     def test_init_telemetry_headers(self):
         api_key = "this-key-42"
         client1 = XataClient(api_key=api_key, workspace_id="ws_id")
-        headers = client1.get_headers()
+        headers1 = client1.get_headers()
 
-        assert len(headers) == 3
-        assert "authorization" in headers
-        assert headers["authorization"] == f"Bearer {api_key}"
-        assert "x-xata-client-id" in headers
-        assert PATTERNS_UUID4.match(headers["x-xata-client-id"])
-        assert "x-xata-session-id" in headers
-        assert PATTERNS_UUID4.match(headers["x-xata-session-id"])
+        assert len(headers1) == 3
+        assert "authorization" in headers1
+        assert headers1["authorization"] == f"Bearer {api_key}"
+        assert "x-xata-client-id" in headers1
+        assert PATTERNS_UUID4.match(headers1["x-xata-client-id"])
+        assert "x-xata-session-id" in headers1
+        assert PATTERNS_UUID4.match(headers1["x-xata-session-id"])
+        assert headers1["x-xata-client-id"] != headers1["x-xata-session-id"]
+
+        api_key = "this-key-42"
+        client2 = XataClient(api_key=api_key, workspace_id="ws_id")
+        headers2 = client2.get_headers()
+
+        assert headers1["x-xata-client-id"] != headers2["x-xata-client-id"]
+        assert headers1["x-xata-session-id"] != headers2["x-xata-session-id"]

--- a/xata/__init__.py
+++ b/xata/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from .client import XataClient
 
 __all__ = ("XataClient",)

--- a/xata/client.py
+++ b/xata/client.py
@@ -115,7 +115,7 @@ class XataClient:
             "authorization": f"Bearer {self.api_key}",
             "x-xata-client-id": str(uuid.uuid4()),
             "x-xata-session-id": str(uuid.uuid4()),
-            # TODO: x-xata-agent
+            "x-xata-agent": f"client=PY_SDK;version={SDK_VERSION};",
         }
 
     def get_config(self) -> dict:

--- a/xata/client.py
+++ b/xata/client.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import os
+import uuid
 from typing import Literal, Optional
 from urllib.parse import urljoin
 
@@ -106,7 +107,11 @@ class XataClient:
         self.branch_name = (
             self.get_branch_name_if_configured() if branch_name is None else branch_name
         )
-        self.headers = {"authorization": f"Bearer {self.api_key}"}
+        self.headers = {
+            "authorization": f"Bearer {self.api_key}",
+            "x-xata-client-id": str(uuid.uuid4()),
+            "x-xata-session-id": str(uuid.uuid4()),
+        }
 
     def get_config(self) -> dict:
         """
@@ -120,6 +125,12 @@ class XataClient:
             "dbName": self.db_name,
             "branchName": self.branch_name,
         }
+
+    def get_headers(self) -> dict:
+        """
+        Get the static headers that are iniatilized on client init.
+        """
+        return self.headers
 
     def get_api_key(self) -> tuple[str, ApiKeyLocation]:
         if os.environ.get("XATA_API_KEY") is not None:

--- a/xata/client.py
+++ b/xata/client.py
@@ -115,6 +115,7 @@ class XataClient:
             "authorization": f"Bearer {self.api_key}",
             "x-xata-client-id": str(uuid.uuid4()),
             "x-xata-session-id": str(uuid.uuid4()),
+            # TODO: x-xata-agent
         }
 
     def get_config(self) -> dict:

--- a/xata/client.py
+++ b/xata/client.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+
+import importlib.metadata
 import json
 import os
 import uuid
@@ -14,6 +16,8 @@ from .errors import (
     RecordNotFoundException,
     UnauthorizedException,
 )
+
+SDK_VERSION = importlib.metadata.version(__package__ or __name__)
 
 PERSONAL_API_KEY_LOCATION = "~/.config/xata/key"
 DEFAULT_BASE_URL_DOMAIN = "xata.sh"
@@ -124,6 +128,7 @@ class XataClient:
             "region": self.region,
             "dbName": self.db_name,
             "branchName": self.branch_name,
+            "version": SDK_VERSION,
         }
 
     def get_headers(self) -> dict:


### PR DESCRIPTION
This PR adds the same telemetry headers as the TS SDK:

- [x] client id (UUID4) header (`x-xata-client-id`)
- [x] session id (UUID4) header (`x-xata-session-id`)
- [ ] agent id header (`x-xata-agent`)

agent id header spec:
value: `client=PY_SDK; version=<client-version>; service=<env>`
service: optional for specifying e.g. integration tests

