### PR TITLE
License header check

### DIFF
--- a/.github/license-header.txt
+++ b/.github/license-header.txt
@@ -1,0 +1,18 @@
+#
+# Licensed to Xatabase, Inc under one or more contributor 
+# license agreements. See the NOTICE file distributed with 
+# this work for additional information regarding copyright 
+# ownership. Xatabase, Inc licenses this file to you under the 
+# Apache License, Version 2.0 (the "License"); you may not 
+# use this file except in compliance with the License. You 
+# may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License. 
+#

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ ipython_config.py
 codegen/ws/*
 .DS_Store
 api-docs/*
+bin
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ api-docs: ## Generate the API documentation
 	mkdir -vp api-docs && rm -Rfv api-docs/*
 	poetry run pdoc3 --html -o api-docs/. xata/.
 
+license-headers-check: ## Check if all *.py files have a license header
+	curl -s https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh | bash
+	./bin/license-header-checker -a .github/license-header.txt . py
+
 code-gen: ## Generate endpoints from OpenAPI specs
 	mkdir -vp codegen/ws/$(scope)
 	rm -Rfv codegen/ws/$(scope)/*


### PR DESCRIPTION
this PR adds a check to ensure all *.py files have the apache-2 license header.

- [ ] make target to manually add the license headers
- [ ] GitHub action to validate the header is present

The library [lluissm/license-header-checker](https://github.com/lluissm/license-header-checker) is used to perform the checks and adding.