### PR TITLE
Codegen with optionals & query params

### DIFF
--- a/codegen/endpoint.tpl
+++ b/codegen/endpoint.tpl
@@ -17,7 +17,19 @@
        url_path = "${path}"
        % endif
        % if params['has_query_params'] :
-       # TODO handle query params
+       query_params = []
+       % for param in params['list']:
+       % if param['in'] == 'query':
+       if ${param['name']} is not None:
+         % if param['trueType'] == 'list' :
+         query_params.append("${param['name']}=%s" % ",".join(${param['name']}))
+         % else :
+         query_params.append(f"${param['name']}={${param['name']}}")
+         % endif
+       % endif
+       % endfor
+       if query_params:
+         url_path += "?" + "&".join(query_params)
        % endif
        % if params['has_payload'] :
        headers = {"content-type": "application/json"}

--- a/codegen/endpoint.tpl
+++ b/codegen/endpoint.tpl
@@ -1,12 +1,12 @@
 
-    def ${operation_id}(self, ${', '.join([f"{p['name']}: {p['type']}" for p in params['list']])}) -> Response:
+    def ${operation_id}(self, ${', '.join([f"{p['nameParam']}: {p['type']}" for p in params['list']])}) -> Response:
        """
        ${description}
        path: ${path}
        method: ${http_method}
 
        % for param in params['list']:
-       :param ${param['name']}: ${param['type']} ${param['description']} [in: ${param['in']}, req: ${param['required']}]
+       :param ${param['nameParam']}: ${param['type']} ${param['description']} [in: ${param['in']}, req: ${param['required']}]
        % endfor
 
        :return Response
@@ -16,20 +16,32 @@
        % else :
        url_path = "${path}"
        % endif
-       % if params['has_query_params'] :
+       % if params['has_query_params'] > 1:
        query_params = []
        % for param in params['list']:
        % if param['in'] == 'query':
-       if ${param['name']} is not None:
+       if ${param['nameParam']} is not None:
          % if param['trueType'] == 'list' :
-         query_params.append("${param['name']}=%s" % ",".join(${param['name']}))
+         query_params.append("${param['name']}=%s" % ",".join(${param['nameParam']}))
          % else :
-         query_params.append(f"${param['name']}={${param['name']}}")
+         query_params.append(f"${param['name']}={${param['nameParam']}}")
          % endif
        % endif
        % endfor
        if query_params:
          url_path += "?" + "&".join(query_params)
+       % endif
+       % if params['has_query_params'] == 1 :
+       % for param in params['list']:
+       % if param['in'] == 'query':
+       if ${param['nameParam']} is not None:
+         % if param['trueType'] == 'list' :
+         url_path += "?${param['name']}=%s" % ",".join(${param['nameParam']})
+         % else :
+         url_path += "?${param['name']}={${param['nameParam']}}"
+         % endif
+       % endif
+       % endfor
        % endif
        % if params['has_payload'] :
        headers = {"content-type": "application/json"}

--- a/codegen/endpoint.tpl
+++ b/codegen/endpoint.tpl
@@ -6,16 +6,18 @@
        method: ${http_method}
 
        % for param in params['list']:
-       % if param != "self":
-       :param ${param['name']}: ${param['type']} ${param['description']}
-       % endif
+       :param ${param['name']}: ${param['type']} ${param['description']} [in: ${param['in']}, req: ${param['required']}]
        % endfor
+
        :return Response
        """
        % if params['has_path_params'] :
        url_path = f"${path}"
        % else :
        url_path = "${path}"
+       % endif
+       % if params['has_query_params'] :
+       # TODO handle query params
        % endif
        % if params['has_payload'] :
        headers = {"content-type": "application/json"}

--- a/codegen/generator.py
+++ b/codegen/generator.py
@@ -170,17 +170,18 @@ def get_endpoint_params(
                 {
                     "name": references[r["$ref"]]["name"].strip(),
                     "type": t,
+                    "trueType": references[references[r["$ref"]]["schema"]["$ref"]][
+                        "type"
+                    ],
                     "description": references[r["$ref"]]["description"].strip(),
                     "in": references[r["$ref"]]["in"],
                     "required": references[r["$ref"]]["required"],
                 }
             )
-            counter_path = (
-                (counter_path + 1) if references[r["$ref"]]["in"] == "path" else 0
-            )
-            counter_query = (
-                (counter_query + 1) if references[r["$ref"]]["in"] == "query" else 0
-            )
+            if references[r["$ref"]]["in"] == "path":
+                counter_path += 1
+            if references[r["$ref"]]["in"] == "query":
+                counter_query += 1
             if not references[r["$ref"]]["required"]:
                 skel["has_optional_params"] = True
         skel["has_path_params"] = counter_path > 0

--- a/xata/namespace.py
+++ b/xata/namespace.py
@@ -50,6 +50,10 @@ class Namespace:
         }  # TODO use "|" when client py min version >= 3.9
         url = "%s/%s" % (self.get_base_url(), url_path.lstrip("/"))
 
+        print("##########")
+        print(url_path)
+        print("##########")
+
         if payload is None:
             resp = request(http_method, url, headers=headers)
         else:

--- a/xata/namespaces/core/authentication.py
+++ b/xata/namespaces/core/authentication.py
@@ -42,6 +42,7 @@ class Authentication(Namespace):
         path: /user/keys
         method: GET
 
+
         :return Response
         """
         url_path = "/user/keys"
@@ -53,7 +54,8 @@ class Authentication(Namespace):
         path: /user/keys/{key_name}
         method: POST
 
-        :param key_name: str API Key name
+        :param key_name: str API Key name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/user/keys/{key_name}"
@@ -65,7 +67,8 @@ class Authentication(Namespace):
         path: /user/keys/{key_name}
         method: DELETE
 
-        :param key_name: str API Key name
+        :param key_name: str API Key name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/user/keys/{key_name}"

--- a/xata/namespaces/core/databases.py
+++ b/xata/namespaces/core/databases.py
@@ -40,7 +40,8 @@ class Databases(Namespace):
         path: /workspaces/{workspace_id}/dbs
         method: GET
 
-        :param workspace_id: str Workspace ID
+        :param workspace_id: str Workspace ID [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/dbs"
@@ -52,8 +53,9 @@ class Databases(Namespace):
         path: /workspaces/{workspace_id}/dbs/{db_name}
         method: GET
 
-        :param workspace_id: str Workspace ID
-        :param db_name: str The Database Name
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param db_name: str The Database Name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/dbs/{db_name}"
@@ -67,9 +69,10 @@ class Databases(Namespace):
         path: /workspaces/{workspace_id}/dbs/{db_name}
         method: PUT
 
-        :param workspace_id: str Workspace ID
-        :param db_name: str The Database Name
-        :param payload: dict Request Body
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param db_name: str The Database Name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/dbs/{db_name}"
@@ -82,8 +85,9 @@ class Databases(Namespace):
         path: /workspaces/{workspace_id}/dbs/{db_name}
         method: DELETE
 
-        :param workspace_id: str Workspace ID
-        :param db_name: str The Database Name
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param db_name: str The Database Name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/dbs/{db_name}"
@@ -97,9 +101,10 @@ class Databases(Namespace):
         path: /workspaces/{workspace_id}/dbs/{db_name}
         method: PATCH
 
-        :param workspace_id: str Workspace ID
-        :param db_name: str The Database Name
-        :param payload: dict Request Body
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param db_name: str The Database Name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/dbs/{db_name}"
@@ -112,7 +117,8 @@ class Databases(Namespace):
         path: /workspaces/{workspace_id}/regions
         method: GET
 
-        :param workspace_id: str Workspace ID
+        :param workspace_id: str Workspace ID [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/regions"

--- a/xata/namespaces/core/invites.py
+++ b/xata/namespaces/core/invites.py
@@ -40,8 +40,9 @@ class Invites(Namespace):
         path: /workspaces/{workspace_id}/invites
         method: POST
 
-        :param workspace_id: str Workspace ID
-        :param payload: dict Request Body
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/invites"
@@ -56,8 +57,9 @@ class Invites(Namespace):
         path: /workspaces/{workspace_id}/invites/{invite_id}
         method: DELETE
 
-        :param workspace_id: str Workspace ID
-        :param invite_id: str Invite identifier
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param invite_id: str Invite identifier [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/invites/{invite_id}"
@@ -71,9 +73,10 @@ class Invites(Namespace):
         path: /workspaces/{workspace_id}/invites/{invite_id}
         method: PATCH
 
-        :param workspace_id: str Workspace ID
-        :param invite_id: str Invite identifier
-        :param payload: dict Request Body
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param invite_id: str Invite identifier [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/invites/{invite_id}"
@@ -88,8 +91,9 @@ class Invites(Namespace):
         path: /workspaces/{workspace_id}/invites/{invite_key}/accept
         method: POST
 
-        :param workspace_id: str Workspace ID
-        :param invite_key: str Invite Key (secret) for the invited user
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param invite_key: str Invite Key (secret) for the invited user [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/invites/{invite_key}/accept"
@@ -103,8 +107,9 @@ class Invites(Namespace):
         path: /workspaces/{workspace_id}/invites/{invite_id}/resend
         method: POST
 
-        :param workspace_id: str Workspace ID
-        :param invite_id: str Invite identifier
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param invite_id: str Invite identifier [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/invites/{invite_id}/resend"

--- a/xata/namespaces/core/users.py
+++ b/xata/namespaces/core/users.py
@@ -42,6 +42,7 @@ class Users(Namespace):
         path: /user
         method: GET
 
+
         :return Response
         """
         url_path = "/user"
@@ -53,7 +54,8 @@ class Users(Namespace):
         path: /user
         method: PUT
 
-        :param payload: dict Request Body
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = "/user"
@@ -67,6 +69,7 @@ class Users(Namespace):
         Delete the user making the request
         path: /user
         method: DELETE
+
 
         :return Response
         """

--- a/xata/namespaces/core/workspaces.py
+++ b/xata/namespaces/core/workspaces.py
@@ -42,6 +42,7 @@ class Workspaces(Namespace):
         path: /workspaces
         method: GET
 
+
         :return Response
         """
         url_path = "/workspaces"
@@ -53,7 +54,8 @@ class Workspaces(Namespace):
         path: /workspaces
         method: POST
 
-        :param payload: dict Request Body
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = "/workspaces"
@@ -66,7 +68,8 @@ class Workspaces(Namespace):
         path: /workspaces/{workspace_id}
         method: GET
 
-        :param workspace_id: str Workspace ID
+        :param workspace_id: str Workspace ID [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}"
@@ -78,8 +81,9 @@ class Workspaces(Namespace):
         path: /workspaces/{workspace_id}
         method: PUT
 
-        :param workspace_id: str Workspace ID
-        :param payload: dict Request Body
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}"
@@ -92,7 +96,8 @@ class Workspaces(Namespace):
         path: /workspaces/{workspace_id}
         method: DELETE
 
-        :param workspace_id: str Workspace ID
+        :param workspace_id: str Workspace ID [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}"
@@ -104,7 +109,8 @@ class Workspaces(Namespace):
         path: /workspaces/{workspace_id}/members
         method: GET
 
-        :param workspace_id: str Workspace ID
+        :param workspace_id: str Workspace ID [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/members"
@@ -118,9 +124,10 @@ class Workspaces(Namespace):
         path: /workspaces/{workspace_id}/members/{user_id}
         method: PUT
 
-        :param workspace_id: str Workspace ID
-        :param user_id: str UserID
-        :param payload: dict Request Body
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param user_id: str UserID [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/members/{user_id}"
@@ -133,8 +140,9 @@ class Workspaces(Namespace):
         path: /workspaces/{workspace_id}/members/{user_id}
         method: DELETE
 
-        :param workspace_id: str Workspace ID
-        :param user_id: str UserID
+        :param workspace_id: str Workspace ID [in: path, req: True]
+        :param user_id: str UserID [in: path, req: True]
+
         :return Response
         """
         url_path = f"/workspaces/{workspace_id}/members/{user_id}"

--- a/xata/namespaces/workspace/branch.py
+++ b/xata/namespaces/workspace/branch.py
@@ -60,7 +60,9 @@ class Branch(Namespace):
         url_path = f"/db/{db_branch_name}"
         return self.request("GET", url_path)
 
-    def createBranch(self, db_branch_name: str, payload: dict) -> Response:
+    def createBranch(
+        self, db_branch_name: str, payload: dict, _from: str = None
+    ) -> Response:
         """
         Create Database branch
         path: /db/{db_branch_name}
@@ -68,24 +70,30 @@ class Branch(Namespace):
 
         :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
         :param payload: dict content [in: requestBody, req: True]
+        :param _from: str = None Name of source branch to branch the new schema from [in: query, req: False]
 
         :return Response
         """
         url_path = f"/db/{db_branch_name}"
+        if _from is not None:
+            url_path += "?from={_from}"
         headers = {"content-type": "application/json"}
         return self.request("PUT", url_path, headers, payload)
 
-    def deleteBranch(self, db_branch_name: str) -> Response:
+    def deleteBranch(self, db_branch_name: str, _from: str = None) -> Response:
         """
         Delete the branch in the database and all its resources
         path: /db/{db_branch_name}
         method: DELETE
 
         :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param _from: str = None Name of source branch to branch the new schema from [in: query, req: False]
 
         :return Response
         """
         url_path = f"/db/{db_branch_name}"
+        if _from is not None:
+            url_path += "?from={_from}"
         return self.request("DELETE", url_path)
 
     def getBranchMetadata(self, db_branch_name: str) -> Response:
@@ -190,7 +198,7 @@ class Branch(Namespace):
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
-    def removeGitBranchesEntry(self, db_name: str) -> Response:
+    def removeGitBranchesEntry(self, db_name: str, gitBranch: str) -> Response:
         """
                Removes an entry from the mapping of git branches to Xata branches. The name of the git branch must be passed as a query parameter. If the git branch is not found, the endpoint returns a 404 status code.
 
@@ -203,13 +211,18 @@ class Branch(Namespace):
                method: DELETE
 
                :param db_name: str The Database Name [in: path, req: True]
+               :param gitBranch: str The Git Branch to remove from the mapping [in: query, req: True]
 
                :return Response
         """
         url_path = f"/dbs/{db_name}/gitbranches"
+        if gitBranch is not None:
+            url_path += "?gitBranch={gitBranch}"
         return self.request("DELETE", url_path)
 
-    def resolveBranch(self, db_name: str) -> Response:
+    def resolveBranch(
+        self, db_name: str, gitBranch: str = None, fallbackBranch: str = None
+    ) -> Response:
         """
                In order to resolve the database branch, the following algorithm is used:
         * if the `gitBranch` was provided and is found in the [git branches mapping](/api-reference/dbs/db_name/gitBranches), the associated Xata branch is returned
@@ -238,8 +251,17 @@ class Branch(Namespace):
                method: GET
 
                :param db_name: str The Database Name [in: path, req: True]
+               :param gitBranch: str = None The Git Branch [in: query, req: False]
+               :param fallbackBranch: str = None Default branch to fallback to [in: query, req: False]
 
                :return Response
         """
         url_path = f"/dbs/{db_name}/resolvebranch"
+        query_params = []
+        if gitBranch is not None:
+            query_params.append(f"gitBranch={gitBranch}")
+        if fallbackBranch is not None:
+            query_params.append(f"fallbackBranch={fallbackBranch}")
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         return self.request("GET", url_path)

--- a/xata/namespaces/workspace/branch.py
+++ b/xata/namespaces/workspace/branch.py
@@ -40,7 +40,8 @@ class Branch(Namespace):
         path: /dbs/{db_name}
         method: GET
 
-        :param db_name: str The Database Name
+        :param db_name: str The Database Name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/dbs/{db_name}"
@@ -52,7 +53,8 @@ class Branch(Namespace):
         path: /db/{db_branch_name}
         method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}"
@@ -64,8 +66,9 @@ class Branch(Namespace):
         path: /db/{db_branch_name}
         method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}"
@@ -78,7 +81,8 @@ class Branch(Namespace):
         path: /db/{db_branch_name}
         method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}"
@@ -90,7 +94,8 @@ class Branch(Namespace):
         path: /db/{db_branch_name}/metadata
         method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/metadata"
@@ -102,8 +107,9 @@ class Branch(Namespace):
         path: /db/{db_branch_name}/metadata
         method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/metadata"
@@ -116,7 +122,8 @@ class Branch(Namespace):
         path: /db/{db_branch_name}/stats
         method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/stats"
@@ -149,7 +156,8 @@ class Branch(Namespace):
                path: /dbs/{db_name}/gitbranches
                method: GET
 
-               :param db_name: str The Database Name
+               :param db_name: str The Database Name [in: path, req: True]
+
                :return Response
         """
         url_path = f"/dbs/{db_name}/gitbranches"
@@ -173,8 +181,9 @@ class Branch(Namespace):
                path: /dbs/{db_name}/gitbranches
                method: POST
 
-               :param db_name: str The Database Name
-               :param payload: dict Request Body
+               :param db_name: str The Database Name [in: path, req: True]
+               :param payload: dict content [in: requestBody, req: True]
+
                :return Response
         """
         url_path = f"/dbs/{db_name}/gitbranches"
@@ -193,7 +202,8 @@ class Branch(Namespace):
                path: /dbs/{db_name}/gitbranches
                method: DELETE
 
-               :param db_name: str The Database Name
+               :param db_name: str The Database Name [in: path, req: True]
+
                :return Response
         """
         url_path = f"/dbs/{db_name}/gitbranches"
@@ -227,7 +237,8 @@ class Branch(Namespace):
                path: /dbs/{db_name}/resolvebranch
                method: GET
 
-               :param db_name: str The Database Name
+               :param db_name: str The Database Name [in: path, req: True]
+
                :return Response
         """
         url_path = f"/dbs/{db_name}/resolvebranch"

--- a/xata/namespaces/workspace/migrations.py
+++ b/xata/namespaces/workspace/migrations.py
@@ -40,8 +40,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/migrations
         method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/migrations"
@@ -54,8 +55,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/migrations/plan
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/migrations/plan"
@@ -70,8 +72,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/migrations/execute
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/migrations/execute"
@@ -84,8 +87,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/schema/history
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/schema/history"
@@ -100,8 +104,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/schema/compare
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/schema/compare"
@@ -116,9 +121,10 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/schema/compare/{branch_name}
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param branch_name: str The Database Name
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param branch_name: str The Database Name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/schema/compare/{branch_name}"
@@ -131,8 +137,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/schema/update
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/schema/update"
@@ -145,8 +152,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/schema/preview
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/schema/preview"
@@ -159,8 +167,9 @@ class Migrations(Namespace):
         path: /db/{db_branch_name}/schema/apply
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/schema/apply"

--- a/xata/namespaces/workspace/records.py
+++ b/xata/namespaces/workspace/records.py
@@ -65,11 +65,8 @@ class Records(Namespace):
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data"
-        query_params = []
         if columns is not None:
-            query_params.append("columns=%s" % ",".join(columns))
-        if query_params:
-            url_path += "?" + "&".join(query_params)
+            url_path += "?columns=%s" % ",".join(columns)
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
@@ -89,11 +86,8 @@ class Records(Namespace):
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
-        query_params = []
         if columns is not None:
-            query_params.append("columns=%s" % ",".join(columns))
-        if query_params:
-            url_path += "?" + "&".join(query_params)
+            url_path += "?columns=%s" % ",".join(columns)
         return self.request("GET", url_path)
 
     def insertRecordWithID(
@@ -103,6 +97,8 @@ class Records(Namespace):
         record_id: str,
         payload: dict,
         columns: list = None,
+        createOnly: bool = None,
+        ifVersion: int = None,
     ) -> Response:
         """
         By default, IDs are auto-generated when data is insterted into Xata. Sending a request to this endpoint allows us to insert a record with a pre-existing ID, bypassing the default automatic ID generation.
@@ -114,6 +110,8 @@ class Records(Namespace):
         :param record_id: str The Record name [in: path, req: True]
         :param payload: dict content [in: requestBody, req: True]
         :param columns: list = None Column filters [in: query, req: False]
+        :param createOnly: bool = None  [in: query, req: False]
+        :param ifVersion: int = None  [in: query, req: False]
 
         :return Response
         """
@@ -121,6 +119,10 @@ class Records(Namespace):
         query_params = []
         if columns is not None:
             query_params.append("columns=%s" % ",".join(columns))
+        if createOnly is not None:
+            query_params.append(f"createOnly={createOnly}")
+        if ifVersion is not None:
+            query_params.append(f"ifVersion={ifVersion}")
         if query_params:
             url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
@@ -133,6 +135,8 @@ class Records(Namespace):
         record_id: str,
         payload: dict,
         columns: list = None,
+        createOnly: bool = None,
+        ifVersion: int = None,
     ) -> Response:
         """
         Upsert record with ID
@@ -144,6 +148,8 @@ class Records(Namespace):
         :param record_id: str The Record name [in: path, req: True]
         :param payload: dict content [in: requestBody, req: True]
         :param columns: list = None Column filters [in: query, req: False]
+        :param createOnly: bool = None  [in: query, req: False]
+        :param ifVersion: int = None  [in: query, req: False]
 
         :return Response
         """
@@ -151,13 +157,23 @@ class Records(Namespace):
         query_params = []
         if columns is not None:
             query_params.append("columns=%s" % ",".join(columns))
+        if createOnly is not None:
+            query_params.append(f"createOnly={createOnly}")
+        if ifVersion is not None:
+            query_params.append(f"ifVersion={ifVersion}")
         if query_params:
             url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def deleteRecord(
-        self, db_branch_name: str, table_name: str, record_id: str, columns: list = None
+        self,
+        db_branch_name: str,
+        table_name: str,
+        record_id: str,
+        columns: list = None,
+        createOnly: bool = None,
+        ifVersion: int = None,
     ) -> Response:
         """
         Delete record from table
@@ -168,6 +184,8 @@ class Records(Namespace):
         :param table_name: str The Table name [in: path, req: True]
         :param record_id: str The Record name [in: path, req: True]
         :param columns: list = None Column filters [in: query, req: False]
+        :param createOnly: bool = None  [in: query, req: False]
+        :param ifVersion: int = None  [in: query, req: False]
 
         :return Response
         """
@@ -175,6 +193,10 @@ class Records(Namespace):
         query_params = []
         if columns is not None:
             query_params.append("columns=%s" % ",".join(columns))
+        if createOnly is not None:
+            query_params.append(f"createOnly={createOnly}")
+        if ifVersion is not None:
+            query_params.append(f"ifVersion={ifVersion}")
         if query_params:
             url_path += "?" + "&".join(query_params)
         return self.request("DELETE", url_path)
@@ -186,6 +208,8 @@ class Records(Namespace):
         record_id: str,
         payload: dict,
         columns: list = None,
+        createOnly: bool = None,
+        ifVersion: int = None,
     ) -> Response:
         """
         Update record with ID
@@ -197,6 +221,8 @@ class Records(Namespace):
         :param record_id: str The Record name [in: path, req: True]
         :param payload: dict content [in: requestBody, req: True]
         :param columns: list = None Column filters [in: query, req: False]
+        :param createOnly: bool = None  [in: query, req: False]
+        :param ifVersion: int = None  [in: query, req: False]
 
         :return Response
         """
@@ -204,6 +230,10 @@ class Records(Namespace):
         query_params = []
         if columns is not None:
             query_params.append("columns=%s" % ",".join(columns))
+        if createOnly is not None:
+            query_params.append(f"createOnly={createOnly}")
+        if ifVersion is not None:
+            query_params.append(f"ifVersion={ifVersion}")
         if query_params:
             url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
@@ -225,10 +255,7 @@ class Records(Namespace):
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/bulk"
-        query_params = []
         if columns is not None:
-            query_params.append("columns=%s" % ",".join(columns))
-        if query_params:
-            url_path += "?" + "&".join(query_params)
+            url_path += "?columns=%s" % ",".join(columns)
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)

--- a/xata/namespaces/workspace/records.py
+++ b/xata/namespaces/workspace/records.py
@@ -40,8 +40,9 @@ class Records(Namespace):
         path: /db/{db_branch_name}/transaction
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/transaction"
@@ -49,38 +50,50 @@ class Records(Namespace):
         return self.request("POST", url_path, headers, payload)
 
     def insertRecord(
-        self, db_branch_name: str, table_name: str, columns: list, payload: dict
+        self, db_branch_name: str, table_name: str, payload: dict, columns: list = None
     ) -> Response:
         """
         Insert a new Record into the Table
         path: /db/{db_branch_name}/tables/{table_name}/data
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param columns: list Column filters
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+        :param columns: list = None Column filters [in: query, req: False]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data"
+        query_params = []
+        if columns is not None:
+            query_params.append("columns=%s" % ",".join(columns))
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def getRecord(
-        self, db_branch_name: str, table_name: str, record_id: str, columns: list
+        self, db_branch_name: str, table_name: str, record_id: str, columns: list = None
     ) -> Response:
         """
         Retrieve record by ID
         path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param record_id: str The Record name
-        :param columns: list Column filters
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param record_id: str The Record name [in: path, req: True]
+        :param columns: list = None Column filters [in: query, req: False]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
+        query_params = []
+        if columns is not None:
+            query_params.append("columns=%s" % ",".join(columns))
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         return self.request("GET", url_path)
 
     def insertRecordWithID(
@@ -88,22 +101,28 @@ class Records(Namespace):
         db_branch_name: str,
         table_name: str,
         record_id: str,
-        columns: list,
         payload: dict,
+        columns: list = None,
     ) -> Response:
         """
         By default, IDs are auto-generated when data is insterted into Xata. Sending a request to this endpoint allows us to insert a record with a pre-existing ID, bypassing the default automatic ID generation.
         path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param record_id: str The Record name
-        :param columns: list Column filters
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param record_id: str The Record name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+        :param columns: list = None Column filters [in: query, req: False]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
+        query_params = []
+        if columns is not None:
+            query_params.append("columns=%s" % ",".join(columns))
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
         return self.request("PUT", url_path, headers, payload)
 
@@ -112,40 +131,52 @@ class Records(Namespace):
         db_branch_name: str,
         table_name: str,
         record_id: str,
-        columns: list,
         payload: dict,
+        columns: list = None,
     ) -> Response:
         """
         Upsert record with ID
         path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param record_id: str The Record name
-        :param columns: list Column filters
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param record_id: str The Record name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+        :param columns: list = None Column filters [in: query, req: False]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
+        query_params = []
+        if columns is not None:
+            query_params.append("columns=%s" % ",".join(columns))
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def deleteRecord(
-        self, db_branch_name: str, table_name: str, record_id: str, columns: list
+        self, db_branch_name: str, table_name: str, record_id: str, columns: list = None
     ) -> Response:
         """
         Delete record from table
         path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param record_id: str The Record name
-        :param columns: list Column filters
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param record_id: str The Record name [in: path, req: True]
+        :param columns: list = None Column filters [in: query, req: False]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
+        query_params = []
+        if columns is not None:
+            query_params.append("columns=%s" % ",".join(columns))
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         return self.request("DELETE", url_path)
 
     def updateRecordWithID(
@@ -153,39 +184,51 @@ class Records(Namespace):
         db_branch_name: str,
         table_name: str,
         record_id: str,
-        columns: list,
         payload: dict,
+        columns: list = None,
     ) -> Response:
         """
         Update record with ID
         path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         method: PATCH
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param record_id: str The Record name
-        :param columns: list Column filters
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param record_id: str The Record name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+        :param columns: list = None Column filters [in: query, req: False]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
+        query_params = []
+        if columns is not None:
+            query_params.append("columns=%s" % ",".join(columns))
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
         return self.request("PATCH", url_path, headers, payload)
 
     def bulkInsertTableRecords(
-        self, db_branch_name: str, table_name: str, columns: list, payload: dict
+        self, db_branch_name: str, table_name: str, payload: dict, columns: list = None
     ) -> Response:
         """
         Bulk insert records
         path: /db/{db_branch_name}/tables/{table_name}/bulk
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param columns: list Column filters
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+        :param columns: list = None Column filters [in: query, req: False]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/bulk"
+        query_params = []
+        if columns is not None:
+            query_params.append("columns=%s" % ",".join(columns))
+        if query_params:
+            url_path += "?" + "&".join(query_params)
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)

--- a/xata/namespaces/workspace/search_and_filter.py
+++ b/xata/namespaces/workspace/search_and_filter.py
@@ -795,9 +795,10 @@ class Search_and_filter(Namespace):
                path: /db/{db_branch_name}/tables/{table_name}/query
                method: POST
 
-               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-               :param table_name: str The Table name
-               :param payload: dict Request Body
+               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+               :param table_name: str The Table name [in: path, req: True]
+               :param payload: dict content [in: requestBody, req: True]
+
                :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/query"
@@ -810,8 +811,9 @@ class Search_and_filter(Namespace):
         path: /db/{db_branch_name}/search
         method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/search"
@@ -830,9 +832,10 @@ class Search_and_filter(Namespace):
                path: /db/{db_branch_name}/tables/{table_name}/search
                method: POST
 
-               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-               :param table_name: str The Table name
-               :param payload: dict Request Body
+               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+               :param table_name: str The Table name [in: path, req: True]
+               :param payload: dict content [in: requestBody, req: True]
+
                :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/search"
@@ -908,9 +911,10 @@ class Search_and_filter(Namespace):
                path: /db/{db_branch_name}/tables/{table_name}/summarize
                method: POST
 
-               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-               :param table_name: str The Table name
-               :param payload: dict Request Body
+               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+               :param table_name: str The Table name [in: path, req: True]
+               :param payload: dict content [in: requestBody, req: True]
+
                :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/summarize"
@@ -932,9 +936,10 @@ class Search_and_filter(Namespace):
                path: /db/{db_branch_name}/tables/{table_name}/aggregate
                method: POST
 
-               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-               :param table_name: str The Table name
-               :param payload: dict Request Body
+               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+               :param table_name: str The Table name [in: path, req: True]
+               :param payload: dict content [in: requestBody, req: True]
+
                :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/aggregate"

--- a/xata/namespaces/workspace/table.py
+++ b/xata/namespaces/workspace/table.py
@@ -40,8 +40,9 @@ class Table(Namespace):
         path: /db/{db_branch_name}/tables/{table_name}
         method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}"
@@ -53,8 +54,9 @@ class Table(Namespace):
         path: /db/{db_branch_name}/tables/{table_name}
         method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}"
@@ -78,9 +80,10 @@ class Table(Namespace):
                path: /db/{db_branch_name}/tables/{table_name}
                method: PATCH
 
-               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-               :param table_name: str The Table name
-               :param payload: dict Request Body
+               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+               :param table_name: str The Table name [in: path, req: True]
+               :param payload: dict content [in: requestBody, req: True]
+
                :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}"
@@ -93,8 +96,9 @@ class Table(Namespace):
         path: /db/{db_branch_name}/tables/{table_name}/schema
         method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/schema"
@@ -108,9 +112,10 @@ class Table(Namespace):
         path: /db/{db_branch_name}/tables/{table_name}/schema
         method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/schema"
@@ -124,8 +129,9 @@ class Table(Namespace):
                path: /db/{db_branch_name}/tables/{table_name}/columns
                method: GET
 
-               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-               :param table_name: str The Table name
+               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+               :param table_name: str The Table name [in: path, req: True]
+
                :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns"
@@ -141,9 +147,10 @@ class Table(Namespace):
                path: /db/{db_branch_name}/tables/{table_name}/columns
                method: POST
 
-               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-               :param table_name: str The Table name
-               :param payload: dict Request Body
+               :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+               :param table_name: str The Table name [in: path, req: True]
+               :param payload: dict content [in: requestBody, req: True]
+
                :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns"
@@ -158,9 +165,10 @@ class Table(Namespace):
         path: /db/{db_branch_name}/tables/{table_name}/columns/{column_name}
         method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param column_name: str The Column name
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param column_name: str The Column name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns/{column_name}"
@@ -174,9 +182,10 @@ class Table(Namespace):
         path: /db/{db_branch_name}/tables/{table_name}/columns/{column_name}
         method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param column_name: str The Column name
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param column_name: str The Column name [in: path, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns/{column_name}"
@@ -190,10 +199,11 @@ class Table(Namespace):
         path: /db/{db_branch_name}/tables/{table_name}/columns/{column_name}
         method: PATCH
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param table_name: str The Table name
-        :param column_name: str The Column name
-        :param payload: dict Request Body
+        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`. [in: path, req: True]
+        :param table_name: str The Table name [in: path, req: True]
+        :param column_name: str The Column name [in: path, req: True]
+        :param payload: dict content [in: requestBody, req: True]
+
         :return Response
         """
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns/{column_name}"


### PR DESCRIPTION
Thus far it was not possible to distinguish between `path` and `query` params. Similarly, if a parameter was required or not. This PR adds these semantics to the generator.