### PR TITLE
Generated smart defaults

### DIFF
--- a/codegen/endpoint.tpl
+++ b/codegen/endpoint.tpl
@@ -13,6 +13,9 @@
 
        :return Response
        """
+       % if params['smart_db_branch_name'] :
+       db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
+       % endif
        % if params['has_path_params'] :
        url_path = f"${path}"
        % else :

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xata"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python client for Xata.io"
 authors = ["Xata <support@xata.io>"]
 license = "Apache-2.0"

--- a/tests/integration-tests/branch_test.py
+++ b/tests/integration-tests/branch_test.py
@@ -18,12 +18,13 @@
 #
 
 import utils
+import pytest
 
 from xata.client import XataClient
 
 
 class TestClass(object):
-    @classmethod
+
     def setup_class(self):
         self.db_name = utils.get_db_name()
         self.branch_name = "main"
@@ -58,7 +59,6 @@ class TestClass(object):
         )
         assert r.status_code == 200
 
-    @classmethod
     def teardown_class(self):
         r = self.client.databases().deleteDatabase(
             self.client.get_config()["workspaceId"], self.db_name
@@ -105,20 +105,17 @@ class TestClass(object):
             payload, branch_name="new-super-duper-feature"
         )
         assert r.status_code == 201
-
-        """
         assert "databaseName" in r.json()
         assert "branchName" in r.json()
         assert "status" in r.json()
         assert r.json()["databaseName"] == self.client.get_config()["dbName"]
-        assert r.json()["branchName"] == payload["metadata"]["branch"]
+        assert r.json()["branchName"] == "new-super-duper-feature"
         assert r.json()["status"] == "completed"
 
         pytest.branch["branch"] = payload
 
-        r = self.client.branch().createBranch(self.client.get_db_branch_name(), payload)
-        assert r.status_code == 422
-        """
+        r = self.client.branch().createBranch(payload, branch_name="the-incredible-hulk", _from="avengers")
+        assert r.status_code == 400
 
         r = self.client.branch().createBranch(
             payload, db_name="NOPE", branch_name=self.branch_name

--- a/tests/integration-tests/branch_test.py
+++ b/tests/integration-tests/branch_test.py
@@ -41,12 +41,11 @@ class TestClass(object):
         assert r.status_code == 201
 
         # create table posts
-        r = self.client.table().createTable(self.client.get_db_branch_name(), "Posts")
+        r = self.client.table().createTable("Posts")
         assert r.status_code == 201
 
         # create schema
         r = self.client.table().setTableSchema(
-            self.client.get_db_branch_name(),
             "Posts",
             {
                 "columns": [
@@ -81,7 +80,7 @@ class TestClass(object):
         assert r.status_code == 404
 
     def test_get_branch_details(self):
-        r = self.client.branch().getBranchDetails(self.client.get_db_branch_name())
+        r = self.client.branch().getBranchDetails()
         assert r.status_code == 200
         assert "databaseName" in r.json()
         assert "branchName" in r.json()
@@ -91,7 +90,7 @@ class TestClass(object):
         # TODO be exhastive testing the ^ dict keys
 
         r = self.client.branch().getBranchDetails("NonExistingDatabase")
-        assert r.status_code == 400
+        assert r.status_code == 404
 
     def test_create_database_branch(self):
         payload = {
@@ -102,10 +101,12 @@ class TestClass(object):
                 "stage": "testing",
             },
         }
-        """
-        r = self.client.branch().createBranch(self.client.get_db_branch_name(), payload)
-        assert r.json() == ""
+        r = self.client.branch().createBranch(
+            payload, branch_name="new-super-duper-feature"
+        )
         assert r.status_code == 201
+
+        """
         assert "databaseName" in r.json()
         assert "branchName" in r.json()
         assert "status" in r.json()
@@ -118,14 +119,17 @@ class TestClass(object):
         r = self.client.branch().createBranch(self.client.get_db_branch_name(), payload)
         assert r.status_code == 422
         """
-        r = self.client.branch().createBranch("NonExistingDbBranchName", payload)
-        assert r.status_code == 400
 
-        r = self.client.branch().createBranch(self.client.get_db_branch_name(), {})
+        r = self.client.branch().createBranch(
+            payload, db_name="NOPE", branch_name=self.branch_name
+        )
+        assert r.status_code == 404
+
+        r = self.client.branch().createBranch({})
         assert r.status_code == 422
 
     def test_get_branch_metadata(self):
-        r = self.client.branch().getBranchMetadata(self.client.get_db_branch_name())
+        r = self.client.branch().getBranchMetadata()
         assert r.status_code == 200
 
         # TODO test from a previously created branch
@@ -133,15 +137,19 @@ class TestClass(object):
         # assert "branch" in r.json()
         # assert "stage" in r.json()
 
-        r = self.client.branch().getBranchMetadata("NonExistingDbBranchName")
-        assert r.status_code == 400
+        r = self.client.branch().getBranchMetadata(branch_name=self.branch_name)
+        assert r.status_code == 200
+        r = self.client.branch().getBranchMetadata(db_name=self.db_name)
+        assert r.status_code == 200
+
+        r = self.client.branch().getBranchMetadata(db_name="NOPE")
+        assert r.status_code == 404
+        r = self.client.branch().getBranchMetadata(branch_name="shrug")
+        assert r.status_code == 404
 
     def test_get_branch_stats(self):
-        r = self.client.branch().getBranchStats(self.client.get_db_branch_name())
+        r = self.client.branch().getBranchStats()
         assert r.status_code == 200
         assert "timestamp" in r.json()
         assert "interval" in r.json()
         # TODO test more ^ dict keys
-
-        r = self.client.branch().getBranchStats("NonExistingDbBranchName")
-        assert r.status_code == 400

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -33,6 +33,10 @@ def pytest_configure():
     pytest.branch = {
         "branch": None,
     }
+    pytest.table = {
+        "client": None,
+        "db_name": None,
+    }
 
 
 def create_demo_db(client: XataClient, db_name: string):

--- a/tests/integration-tests/table_test.py
+++ b/tests/integration-tests/table_test.py
@@ -36,7 +36,7 @@ class TestClass(object):
             self.db_name,
             {
                 "region": self.client.get_config()["region"],
-                "branchName": self.client.get_config()["branchName"],
+                "branchName": self.branch_name,
             },
         )
         assert r.status_code == 201
@@ -67,7 +67,9 @@ class TestClass(object):
     # Table Ops
     #
     def test_create_table(self):
-        r = self.client.table().createTable(self.client.get_db_branch_name(), "Posts")
+        r = self.client.table().createTable(
+            "Posts", db_name=self.db_name, branch_name=self.branch_name
+        )
         assert r.status_code == 201
         assert r.json()["status"] == "completed"
         assert r.json()["tableName"] == "Posts"
@@ -75,12 +77,15 @@ class TestClass(object):
 
     def test_update_table(self):
         r = self.client.table().createTable(
-            self.client.get_db_branch_name(), "RenameMe"
+            "RenameMe", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 201
 
         r = self.client.table().updateTable(
-            self.client.get_db_branch_name(), "RenameMe", {"name": "NewName"}
+            "RenameMe",
+            {"name": "NewName"},
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 200
         assert r.json()["status"] == "completed"
@@ -89,18 +94,18 @@ class TestClass(object):
 
     def test_delete_table(self):
         r = self.client.table().createTable(
-            self.client.get_db_branch_name(), "DeleteMe"
+            "DeleteMe", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 201
 
         r = self.client.table().deleteTable(
-            self.client.get_db_branch_name(), "DeleteMe"
+            "DeleteMe", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
         assert r.json()["status"] == "completed"
 
         r = self.client.table().deleteTable(
-            self.client.get_db_branch_name(), "NonExistingTable"
+            "NonExistingTable", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 404
 
@@ -109,24 +114,27 @@ class TestClass(object):
     #
     def test_set_table_schema(self, columns: dict):
         r = self.client.table().setTableSchema(
-            self.client.get_db_branch_name(), "Posts", columns
+            "Posts", columns, db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
 
         r = self.client.table().setTableSchema(
-            self.client.get_db_branch_name(), "NonExistingTable", columns
+            "NonExistingTable",
+            columns,
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 404
 
     def test_get_table_schema(self, columns):
         r = self.client.table().getTableSchema(
-            self.client.get_db_branch_name(), "Posts"
+            "Posts", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
         assert columns == r.json()
 
         r = self.client.table().getTableSchema(
-            self.client.get_db_branch_name(), "NonExistingTable"
+            "NonExistingTable", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 404
 
@@ -135,19 +143,19 @@ class TestClass(object):
     #
     def test_get_table_columns(self, columns: dict):
         r = self.client.table().getTableColumns(
-            self.client.get_db_branch_name(), "Posts"
+            "Posts", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
         assert r.json() == columns
 
         r = self.client.table().getTableColumns(
-            self.client.get_db_branch_name(), "NonExistingTable"
+            "NonExistingTable", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 404
 
     def test_add_column(self, columns: dict, new_column: dict):
         r = self.client.table().addTableColumn(
-            self.client.get_db_branch_name(), "Posts", new_column
+            "Posts", new_column, db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
         assert r.json()["status"] == "completed"
@@ -155,47 +163,63 @@ class TestClass(object):
         assert "parentMigrationID" in r.json()
 
         r = self.client.table().getTableColumns(
-            self.client.get_db_branch_name(), "Posts"
+            "Posts", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
         columns["columns"].append(new_column)
         assert r.json() == columns
 
         r = self.client.table().addTableColumn(
-            self.client.get_db_branch_name(), "NonExistingTable", {"name": "foo"}
+            "NonExistingTable",
+            {"name": "foo"},
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 404
 
         r = self.client.table().addTableColumn(
-            self.client.get_db_branch_name(), "Posts", {"name": "foo"}
+            "Posts", {"name": "foo"}, db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 400
         r = self.client.table().addTableColumn(
-            self.client.get_db_branch_name(), "Posts", {"type": "bar"}
+            "Posts", {"type": "bar"}, db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 400
 
     def test_get_column(self, new_column: dict):
         r = self.client.table().getColumn(
-            self.client.get_db_branch_name(), "Posts", new_column["name"]
+            "Posts",
+            new_column["name"],
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 200
         assert r.json() == new_column
 
         r = self.client.table().getColumn(
-            self.client.get_db_branch_name(), "Posts", "NonExistingColumn"
+            "Posts",
+            "NonExistingColumn",
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 404
 
         r = self.client.table().getColumn(
-            self.client.get_db_branch_name(), "NonExistingTable", new_column["name"]
+            "NonExistingTable",
+            new_column["name"],
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 404
 
     def test_update_column(self, new_column: dict):
         newer_column = {"name": "a-newer-column"}
         r = self.client.table().updateColumn(
-            self.client.get_db_branch_name(), "Posts", new_column["name"], newer_column
+            "Posts",
+            new_column["name"],
+            newer_column,
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 200
         assert r.json()["status"] == "completed"
@@ -203,40 +227,57 @@ class TestClass(object):
         assert "parentMigrationID" in r.json()
 
         r = self.client.table().getColumn(
-            self.client.get_db_branch_name(), "Posts", newer_column["name"]
+            "Posts",
+            newer_column["name"],
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 200
 
         r = self.client.table().updateColumn(
-            self.client.get_db_branch_name(), "Posts", newer_column["name"], {}
+            "Posts",
+            newer_column["name"],
+            {},
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 400
 
         r = self.client.table().updateColumn(
-            self.client.get_db_branch_name(), "Posts", new_column["name"], newer_column
+            "Posts",
+            new_column["name"],
+            newer_column,
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 404
         r = self.client.table().updateColumn(
-            self.client.get_db_branch_name(),
             "NonExistingTable",
             new_column["name"],
             newer_column,
         )
         assert r.status_code == 404
         r = self.client.table().updateColumn(
-            self.client.get_db_branch_name(), "Posts", "NonExistingColumn", newer_column
+            "Posts",
+            "NonExistingColumn",
+            newer_column,
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 404
 
     def test_delete_column(self, columns: dict):
         r = self.client.table().getTableColumns(
-            self.client.get_db_branch_name(), "Posts"
+            "Posts", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
         assert (len(r.json()["columns"]) - 1) == len(columns["columns"])
 
         r = self.client.table().deleteColumn(
-            self.client.get_db_branch_name(), "Posts", "a-newer-column"
+            "Posts",
+            "a-newer-column",
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 200
         assert r.json()["status"] == "completed"
@@ -244,12 +285,15 @@ class TestClass(object):
         assert "parentMigrationID" in r.json()
 
         r = self.client.table().getColumn(
-            self.client.get_db_branch_name(), "Posts", "a-newer-column"
+            "Posts",
+            "a-newer-column",
+            db_name=self.db_name,
+            branch_name=self.branch_name,
         )
         assert r.status_code == 404
 
         r = self.client.table().getTableColumns(
-            self.client.get_db_branch_name(), "Posts"
+            "Posts", db_name=self.db_name, branch_name=self.branch_name
         )
         assert r.status_code == 200
         assert r.json() == columns

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -28,7 +28,7 @@ from xata.client import XataClient
 
 
 def get_db_name() -> str:
-    return f"{datetime.today().strftime('%Y-%d-%m')}-sdk-py-e2e-test-{get_random_string(6)}"
+    return f"sdk-py-e2e-test-{get_random_string(6)}"
 
 
 def wait_until_records_are_indexed(table: str):

--- a/xata/client.py
+++ b/xata/client.py
@@ -46,7 +46,7 @@ from .namespaces.workspace.table import Table
 
 # TODO this is a manual task, to keep in sync with pyproject.toml
 # could/should be automated to keep in sync
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 PERSONAL_API_KEY_LOCATION = "~/.config/xata/key"
 DEFAULT_BASE_URL_DOMAIN = "xata.sh"

--- a/xata/client.py
+++ b/xata/client.py
@@ -222,9 +222,9 @@ class XataClient:
         :return str
         """
         if db_name is None:
-            db_name = self.get_config()["dbName"]
+            db_name = self.db_name
         if branch_name is None:
-            branch_name = self.get_config()["branchName"]
+            branch_name = self.branch_name
         return f"{db_name}:{branch_name}"
 
     def request(self, method, urlPath, cp=False, headers={}, expect_codes=[], **kwargs):

--- a/xata/client.py
+++ b/xata/client.py
@@ -52,6 +52,7 @@ PERSONAL_API_KEY_LOCATION = "~/.config/xata/key"
 DEFAULT_BASE_URL_DOMAIN = "xata.sh"
 DEFAULT_CONTROL_PLANE_DOMAIN = "api.xata.io"
 DEFAULT_REGION = "us-east-1"
+DEFAULT_BRANCH_NAME = "main"
 CONFIG_LOCATION = ".xatarc"
 
 ApiKeyLocation = Literal["env", "dotenv", "profile", "parameter"]
@@ -75,7 +76,7 @@ class XataClient:
     :param workspace_id: The workspace ID to use.
     :param region: The region to use.
     :param db_name: The database name to use.
-    :param branch_name: The branch name to use.
+    :param branch_name: The branch name to use. Defaults to `main`
     :param base_url_domain: The domain to use for the base URL. Defaults to xata.sh.
     :param control_plane_domain: The domain to use for the control plane. Defaults to api.xata.io.
     """
@@ -93,7 +94,7 @@ class XataClient:
         workspace_id: str = None,
         db_name: str = None,
         db_url: str = None,
-        branch_name: str = None,
+        branch_name: str = DEFAULT_BRANCH_NAME,
     ):
         """Constructor for the XataClient."""
         if db_url is not None:

--- a/xata/namespace.py
+++ b/xata/namespace.py
@@ -32,7 +32,7 @@ class Namespace:
 
     def get_scope(self) -> str:
         return self.scope
-    
+
     def is_control_plane(self) -> bool:
         return self.get_scope() == "core"
 

--- a/xata/namespace.py
+++ b/xata/namespace.py
@@ -29,13 +29,15 @@ class Namespace:
 
     def __init__(self, client):
         self.client = client
-        self.is_control_plane = self.get_scope() == "core"
 
     def get_scope(self) -> str:
         return self.scope
+    
+    def is_control_plane(self) -> bool:
+        return self.get_scope() == "core"
 
     def get_base_url(self) -> str:
-        if self.is_control_plane:
+        if self.is_control_plane():
             return self.base_url
         # Base URL must be build on the fly as the region & workspace Id can change
         return self.base_url.replace(

--- a/xata/namespaces/workspace/branch.py
+++ b/xata/namespaces/workspace/branch.py
@@ -47,90 +47,112 @@ class Branch(Namespace):
         url_path = f"/dbs/{db_name}"
         return self.request("GET", url_path)
 
-    def getBranchDetails(self, db_branch_name: str) -> Response:
+    def getBranchDetails(
+        self, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Get branch schema and metadata
         Path: /db/{db_branch_name}
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}"
         return self.request("GET", url_path)
 
     def createBranch(
-        self, db_branch_name: str, payload: dict, _from: str = None
+        self,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
+        _from: str = None,
     ) -> Response:
         """
         Create Database branch
         Path: /db/{db_branch_name}
         Method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param _from: str = None Name of source branch to branch the new schema from
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}"
         if _from is not None:
             url_path += "?from={_from}"
         headers = {"content-type": "application/json"}
         return self.request("PUT", url_path, headers, payload)
 
-    def deleteBranch(self, db_branch_name: str) -> Response:
+    def deleteBranch(self, db_name: str = None, branch_name: str = None) -> Response:
         """
         Delete the branch in the database and all its resources
         Path: /db/{db_branch_name}
         Method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}"
         return self.request("DELETE", url_path)
 
-    def getBranchMetadata(self, db_branch_name: str) -> Response:
+    def getBranchMetadata(
+        self, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Get Branch Metadata
         Path: /db/{db_branch_name}/metadata
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/metadata"
         return self.request("GET", url_path)
 
-    def updateBranchMetadata(self, db_branch_name: str, payload: dict) -> Response:
+    def updateBranchMetadata(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Update the branch metadata
         Path: /db/{db_branch_name}/metadata
         Method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/metadata"
         headers = {"content-type": "application/json"}
         return self.request("PUT", url_path, headers, payload)
 
-    def getBranchStats(self, db_branch_name: str) -> Response:
+    def getBranchStats(self, db_name: str = None, branch_name: str = None) -> Response:
         """
         Get branch usage metrics.
         Path: /db/{db_branch_name}/stats
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/stats"
         return self.request("GET", url_path)
 

--- a/xata/namespaces/workspace/migrations.py
+++ b/xata/namespaces/workspace/migrations.py
@@ -34,144 +34,173 @@ class Migrations(Namespace):
     base_url = "https://{workspaceId}.{regionId}.xata.sh"
     scope = "workspace"
 
-    def getBranchMigrationHistory(self, db_branch_name: str, payload: dict) -> Response:
+    def getBranchMigrationHistory(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Get branch migration history [deprecated]
         Path: /db/{db_branch_name}/migrations
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/migrations"
         headers = {"content-type": "application/json"}
         return self.request("GET", url_path, headers, payload)
 
-    def getBranchMigrationPlan(self, db_branch_name: str, payload: dict) -> Response:
+    def getBranchMigrationPlan(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Compute a migration plan from a target schema the branch should be migrated too.
         Path: /db/{db_branch_name}/migrations/plan
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/migrations/plan"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def executeBranchMigrationPlan(
-        self, db_branch_name: str, payload: dict
+        self, payload: dict, db_name: str = None, branch_name: str = None
     ) -> Response:
         """
         Apply a migration plan to the branch
         Path: /db/{db_branch_name}/migrations/execute
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/migrations/execute"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
-    def getBranchSchemaHistory(self, db_branch_name: str, payload: dict) -> Response:
+    def getBranchSchemaHistory(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Query schema history.
         Path: /db/{db_branch_name}/schema/history
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/schema/history"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def compareBranchWithUserSchema(
-        self, db_branch_name: str, payload: dict
+        self, payload: dict, db_name: str = None, branch_name: str = None
     ) -> Response:
         """
         Compare branch with user schema.
         Path: /db/{db_branch_name}/schema/compare
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/schema/compare"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def compareBranchSchemas(
-        self, db_branch_name: str, branch_name: str, payload: dict
+        self, payload: dict, db_name: str = None, branch_name: str = None
     ) -> Response:
         """
         Compare branch schemas.
         Path: /db/{db_branch_name}/schema/compare/{branch_name}
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
-        :param branch_name: str The Database Name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/schema/compare/{branch_name}"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
-    def updateBranchSchema(self, db_branch_name: str, payload: dict) -> Response:
+    def updateBranchSchema(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Update Branch schema
         Path: /db/{db_branch_name}/schema/update
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/schema/update"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
-    def previewBranchSchemaEdit(self, db_branch_name: str, payload: dict) -> Response:
+    def previewBranchSchemaEdit(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Preview branch schema edits.
         Path: /db/{db_branch_name}/schema/preview
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/schema/preview"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
-    def applyBranchSchemaEdit(self, db_branch_name: str, payload: dict) -> Response:
+    def applyBranchSchemaEdit(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Apply edit script.
         Path: /db/{db_branch_name}/schema/apply
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/schema/apply"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)

--- a/xata/namespaces/workspace/records.py
+++ b/xata/namespaces/workspace/records.py
@@ -34,36 +34,47 @@ class Records(Namespace):
     base_url = "https://{workspaceId}.{regionId}.xata.sh"
     scope = "workspace"
 
-    def branchTransaction(self, db_branch_name: str, payload: dict) -> Response:
+    def branchTransaction(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Execute a transaction on a branch
         Path: /db/{db_branch_name}/transaction
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/transaction"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def insertRecord(
-        self, db_branch_name: str, table_name: str, payload: dict, columns: list = None
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
+        columns: list = None,
     ) -> Response:
         """
         Insert a new Record into the Table
         Path: /db/{db_branch_name}/tables/{table_name}/data
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param columns: list = None Column filters
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data"
         if columns is not None:
             url_path += "?columns=%s" % ",".join(columns)
@@ -71,20 +82,27 @@ class Records(Namespace):
         return self.request("POST", url_path, headers, payload)
 
     def getRecord(
-        self, db_branch_name: str, table_name: str, record_id: str, columns: list = None
+        self,
+        table_name: str,
+        record_id: str,
+        db_name: str = None,
+        branch_name: str = None,
+        columns: list = None,
     ) -> Response:
         """
         Retrieve record by ID
         Path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param record_id: str The Record name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param columns: list = None Column filters
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
         if columns is not None:
             url_path += "?columns=%s" % ",".join(columns)
@@ -92,10 +110,11 @@ class Records(Namespace):
 
     def insertRecordWithID(
         self,
-        db_branch_name: str,
         table_name: str,
         record_id: str,
         payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
         columns: list = None,
         createOnly: bool = None,
         ifVersion: int = None,
@@ -107,16 +126,18 @@ class Records(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         Method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param record_id: str The Record name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param columns: list = None Column filters
         :param createOnly: bool = None
         :param ifVersion: int = None
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
         query_params = []
         if columns is not None:
@@ -132,10 +153,11 @@ class Records(Namespace):
 
     def upsertRecordWithID(
         self,
-        db_branch_name: str,
         table_name: str,
         record_id: str,
         payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
         columns: list = None,
         ifVersion: int = None,
     ) -> Response:
@@ -144,15 +166,17 @@ class Records(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param record_id: str The Record name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param columns: list = None Column filters
         :param ifVersion: int = None
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
         query_params = []
         if columns is not None:
@@ -165,20 +189,27 @@ class Records(Namespace):
         return self.request("POST", url_path, headers, payload)
 
     def deleteRecord(
-        self, db_branch_name: str, table_name: str, record_id: str, columns: list = None
+        self,
+        table_name: str,
+        record_id: str,
+        db_name: str = None,
+        branch_name: str = None,
+        columns: list = None,
     ) -> Response:
         """
         Delete record from table
         Path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         Method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param record_id: str The Record name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param columns: list = None Column filters
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
         if columns is not None:
             url_path += "?columns=%s" % ",".join(columns)
@@ -186,10 +217,11 @@ class Records(Namespace):
 
     def updateRecordWithID(
         self,
-        db_branch_name: str,
         table_name: str,
         record_id: str,
         payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
         columns: list = None,
         ifVersion: int = None,
     ) -> Response:
@@ -198,15 +230,17 @@ class Records(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/data/{record_id}
         Method: PATCH
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param record_id: str The Record name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param columns: list = None Column filters
         :param ifVersion: int = None
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/data/{record_id}"
         query_params = []
         if columns is not None:
@@ -219,20 +253,27 @@ class Records(Namespace):
         return self.request("PATCH", url_path, headers, payload)
 
     def bulkInsertTableRecords(
-        self, db_branch_name: str, table_name: str, payload: dict, columns: list = None
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
+        columns: list = None,
     ) -> Response:
         """
         Bulk insert records
         Path: /db/{db_branch_name}/tables/{table_name}/bulk
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
         :param columns: list = None Column filters
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/bulk"
         if columns is not None:
             url_path += "?columns=%s" % ",".join(columns)

--- a/xata/namespaces/workspace/search_and_filter.py
+++ b/xata/namespaces/workspace/search_and_filter.py
@@ -35,7 +35,11 @@ class Search_and_filter(Namespace):
     scope = "workspace"
 
     def queryTable(
-        self, db_branch_name: str, table_name: str, payload: dict
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         The Query Table API can be used to retrieve all records in a table.  The API support
@@ -207,33 +211,43 @@ class Search_and_filter(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/query
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/query"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
-    def searchBranch(self, db_branch_name: str, payload: dict) -> Response:
+    def searchBranch(
+        self, payload: dict, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Run a free text search operation across the database branch.
         Path: /db/{db_branch_name}/search
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/search"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def searchTable(
-        self, db_branch_name: str, table_name: str, payload: dict
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         Run a free text search operation in a particular table.  The endpoint accepts a `query`
@@ -246,18 +260,24 @@ class Search_and_filter(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/search
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/search"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def summarizeTable(
-        self, db_branch_name: str, table_name: str, payload: dict
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         This endpoint allows you to (optionally) define groups, and then to run calculations on
@@ -296,18 +316,24 @@ class Search_and_filter(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/summarize
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/summarize"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def aggregateTable(
-        self, db_branch_name: str, table_name: str, payload: dict
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         This endpoint allows you to run aggragations (analytics) on the data from one table.
@@ -320,12 +346,14 @@ class Search_and_filter(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/aggregate
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/aggregate"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)

--- a/xata/namespaces/workspace/table.py
+++ b/xata/namespaces/workspace/table.py
@@ -34,37 +34,49 @@ class Table(Namespace):
     base_url = "https://{workspaceId}.{regionId}.xata.sh"
     scope = "workspace"
 
-    def createTable(self, db_branch_name: str, table_name: str) -> Response:
+    def createTable(
+        self, table_name: str, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Creates a new table with the given name.  Returns 422 if a table with the same name
         already exists.
         Path: /db/{db_branch_name}/tables/{table_name}
         Method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}"
         return self.request("PUT", url_path)
 
-    def deleteTable(self, db_branch_name: str, table_name: str) -> Response:
+    def deleteTable(
+        self, table_name: str, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Deletes the table with the given name.
         Path: /db/{db_branch_name}/tables/{table_name}
         Method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}"
         return self.request("DELETE", url_path)
 
     def updateTable(
-        self, db_branch_name: str, table_name: str, payload: dict
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         Update table.  Currently there is only one update operation supported: renaming the table
@@ -73,49 +85,63 @@ class Table(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}
         Method: PATCH
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}"
         headers = {"content-type": "application/json"}
         return self.request("PATCH", url_path, headers, payload)
 
-    def getTableSchema(self, db_branch_name: str, table_name: str) -> Response:
+    def getTableSchema(
+        self, table_name: str, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Get table schema
         Path: /db/{db_branch_name}/tables/{table_name}/schema
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/schema"
         return self.request("GET", url_path)
 
     def setTableSchema(
-        self, db_branch_name: str, table_name: str, payload: dict
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         Update table schema
         Path: /db/{db_branch_name}/tables/{table_name}/schema
         Method: PUT
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/schema"
         headers = {"content-type": "application/json"}
         return self.request("PUT", url_path, headers, payload)
 
-    def getTableColumns(self, db_branch_name: str, table_name: str) -> Response:
+    def getTableColumns(
+        self, table_name: str, db_name: str = None, branch_name: str = None
+    ) -> Response:
         """
         Retrieves the list of table columns and their definition.  This endpoint returns the
         column list with object columns being reported with their full dot-separated path
@@ -123,16 +149,22 @@ class Table(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/columns
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns"
         return self.request("GET", url_path)
 
     def addTableColumn(
-        self, db_branch_name: str, table_name: str, payload: dict
+        self,
+        table_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         Adds a new column to the table.  The body of the request should contain the column
@@ -143,18 +175,24 @@ class Table(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/columns
         Method: POST
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns"
         headers = {"content-type": "application/json"}
         return self.request("POST", url_path, headers, payload)
 
     def getColumn(
-        self, db_branch_name: str, table_name: str, column_name: str
+        self,
+        table_name: str,
+        column_name: str,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         Get the definition of a single column.  To refer to sub-objects, the column name can
@@ -162,17 +200,23 @@ class Table(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/columns/{column_name}
         Method: GET
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param column_name: str The Column name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns/{column_name}"
         return self.request("GET", url_path)
 
     def deleteColumn(
-        self, db_branch_name: str, table_name: str, column_name: str
+        self,
+        table_name: str,
+        column_name: str,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         Deletes the specified column.  To refer to sub-objects, the column name can contain dots.
@@ -180,17 +224,24 @@ class Table(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/columns/{column_name}
         Method: DELETE
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param column_name: str The Column name
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns/{column_name}"
         return self.request("DELETE", url_path)
 
     def updateColumn(
-        self, db_branch_name: str, table_name: str, column_name: str, payload: dict
+        self,
+        table_name: str,
+        column_name: str,
+        payload: dict,
+        db_name: str = None,
+        branch_name: str = None,
     ) -> Response:
         """
         Update column with partial data.  Can be used for renaming the column by providing a new
@@ -199,13 +250,15 @@ class Table(Namespace):
         Path: /db/{db_branch_name}/tables/{table_name}/columns/{column_name}
         Method: PATCH
 
-        :param db_branch_name: str The DBBranchName matches the pattern `{db_name}:{branch_name}`.
         :param table_name: str The Table name
         :param column_name: str The Column name
         :param payload: dict content
+        :param db_name: str = None The name of the database to query. Default: database name from the client.
+        :param branch_name: str = None The name of the branch to query. Default: branch name from the client.
 
         :return Response
         """
+        db_branch_name = self.client.get_db_branch_name(db_name, branch_name)
         url_path = f"/db/{db_branch_name}/tables/{table_name}/columns/{column_name}"
         headers = {"content-type": "application/json"}
         return self.request("PATCH", url_path, headers, payload)


### PR DESCRIPTION
Improve the client's UX by not requesting the parameter `db_branch_name` as mandatory. Split up in `db_name` and `branch_name`, which are both optional and if left blank, use the client's internal state. This creates leaner method signatures.

ref #24 