### PR TITLE
Duplicate branch name tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xata"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python client for Xata.io"
 authors = ["Xata <support@xata.io>"]
 license = "Apache-2.0"

--- a/tests/unit-tests/client_internals_test.py
+++ b/tests/unit-tests/client_internals_test.py
@@ -64,6 +64,14 @@ class TestClientInternals(unittest.TestCase):
         assert client.get_db_branch_name("foo") == f"foo:{branch_name}"
         assert client.get_db_branch_name("foo", "bar") == "foo:bar"
 
+    def test_get_db_branch_name_with_db_url(self):
+        db_url = "https://py-sdk-unit-test-12345.eu-west-1.xata.sh/db/testopia-042:main"
+        client = XataClient(api_key="api_key", db_url=db_url)
+
+        assert "testopia-042" == client.get_config()["dbName"]
+        assert "main" == client.get_config()["branchName"]
+        assert "testopia-042:main" == client.get_db_branch_name()
+
     def test_get_config(self):
         api_key = "api_key-abc"
         ws_id = "ws-idddddd"

--- a/xata/client.py
+++ b/xata/client.py
@@ -309,14 +309,14 @@ class XataClient:
         (_, _, host, _, db_branch_name) = databaseURL.split("/")
         if host == "" or db_branch_name == "":
             raise Exception(
-                "Invalid database URL: '%s', format: 'https://{workspace_id}.{region}.xata.sh/db/{db_name}' expected."
+                "Invalid database URL: '%s', format: 'https://{workspace_id}.{region}.xata.sh/db/{db_name}:{branch_name}' expected."
                 % databaseURL
             )
         # split host {workspace_id}.{region}
         host_parts = host.split(".")
         if len(host_parts) < 4:
             raise Exception(
-                "Invalid format for workspaceId and region in the URL: '%s', expected: 'https://{workspace_id}.{region}.xata.sh/db/{db_name}'"
+                "Invalid format for workspaceId and region in the URL: '%s', expected: 'https://{workspace_id}.{region}.xata.sh/db/{db_name}:{branch_name}'"
                 % databaseURL
             )
         # build domain name

--- a/xata/client.py
+++ b/xata/client.py
@@ -47,7 +47,7 @@ from .namespaces.workspace.table import Table
 
 # TODO this is a manual task, to keep in sync with pyproject.toml
 # could/should be automated to keep in sync
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 PERSONAL_API_KEY_LOCATION = "~/.config/xata/key"
 DEFAULT_DATA_PLANE_DOMAIN = "xata.sh"


### PR DESCRIPTION
The bug reported in #65 was reproducible in the `0.7.0` of the client and has been fixed beforehand with the expansion of `_parse_database_url()`. This PR adds one more unit test to ensure the case is covered. Closes #65 