### PR TITLE
Remove lazy loading concept

### DIFF
--- a/tests/integration-tests/namespace_test.py
+++ b/tests/integration-tests/namespace_test.py
@@ -31,7 +31,7 @@ class TestNamespace(object):
         users = XataClient().users()
         r1 = users.getUser()
         assert r1.status_code == 200
-        
+
         client = XataClient()
         r2 = client.users().getUser()
         assert r2.status_code == 200
@@ -50,5 +50,3 @@ class TestNamespace(object):
         assert databases.createDatabase(db_name, {"region": "eu-west-1"}).status_code == 201
         assert databases.getDatabaseMetadata(db_name).status_code == 200
         assert databases.deleteDatabase(db_name).status_code == 200
-
-

--- a/tests/integration-tests/search_and_filter_with_alias_test.py
+++ b/tests/integration-tests/search_and_filter_with_alias_test.py
@@ -93,9 +93,7 @@ class TestSearchAndFilterWithAliasNamespace(object):
             "sort": {"slug": "desc"},
             "page": {"size": 5},
         }
-        r = self.client.data().queryTable(
-            "Posts", payload, db_name=self.db_name, branch_name=self.branch_name
-        )
+        r = self.client.data().queryTable("Posts", payload, db_name=self.db_name, branch_name=self.branch_name)
         assert r.status_code == 200
         assert "records" in r.json()
         assert len(r.json()["records"]) == 5
@@ -125,9 +123,7 @@ class TestSearchAndFilterWithAliasNamespace(object):
         POST /db/{db_branch_name}/tables/{table_name}/search
         """
         payload = {"query": self.posts[0]["title"]}
-        r = self.client.data().searchTable(
-            "Posts", payload, db_name=self.db_name, branch_name=self.branch_name
-        )
+        r = self.client.data().searchTable("Posts", payload, db_name=self.db_name, branch_name=self.branch_name)
         assert r.status_code == 200
         assert "records" in r.json()
         assert len(r.json()["records"]) >= 1

--- a/tests/unit-tests/helpers_to_rfc3339.py
+++ b/tests/unit-tests/helpers_to_rfc3339.py
@@ -18,11 +18,12 @@
 #
 
 import unittest
-
-from pytz import timezone, utc
 from datetime import datetime
 
+from pytz import timezone, utc
+
 from xata.helpers import to_rfc339
+
 
 class TestHelpersToRfc3339(unittest.TestCase):
     def test_to_rfc3339(self):

--- a/xata/client.py
+++ b/xata/client.py
@@ -769,9 +769,7 @@ class XataClient:
         scope: core
         :return Databases
         """
-        if "databases" not in self.namespaces:
-            self.namespaces["databases"] = Databases(self)
-        return self.namespaces["databases"]
+        return Databases(self)
 
     def invites(self) -> Invites:
         """
@@ -779,9 +777,7 @@ class XataClient:
         scope: core
         :return Invites
         """
-        if "invites" not in self.namespaces:
-            self.namespaces["invites"] = Invites(self)
-        return self.namespaces["invites"]
+        return Invites(self)
 
     def users(self) -> Users:
         """
@@ -789,9 +785,7 @@ class XataClient:
         scope: core
         :return Users
         """
-        if "users" not in self.namespaces:
-            self.namespaces["users"] = Users(self)
-        return self.namespaces["users"]
+        return Users(self)
 
     def workspaces(self) -> Workspaces:
         """
@@ -799,9 +793,7 @@ class XataClient:
         scope: core
         :return Workspaces
         """
-        if "workspaces" not in self.namespaces:
-            self.namespaces["workspaces"] = Workspaces(self)
-        return self.namespaces["workspaces"]
+        return Workspaces(self)
 
     # --------------------------------------------------- #
     #
@@ -814,51 +806,39 @@ class XataClient:
         Branch Namespace
         :return Branch
         """
-        if "branch" not in self.namespaces:
-            self.namespaces["branch"] = Branch(self)
-        return self.namespaces["branch"]
+        return Branch(self)
 
     def migrations(self) -> Migrations:
         """
         Migrations Namespace
         :return Migrations
         """
-        if "migrations" not in self.namespaces:
-            self.namespaces["migrations"] = Migrations(self)
-        return self.namespaces["migrations"]
+        return Migrations(self)
 
     def records(self) -> Records:
         """
         Records Namespace
         :return Records
         """
-        if "records" not in self.namespaces:
-            self.namespaces["records"] = Records(self)
-        return self.namespaces["records"]
+        return Records(self)
 
     def search_and_filter(self) -> Search_and_filter:
         """
         Search_and_Filter Namespace
         :return Search_and_filter
         """
-        if "search_and_filter" not in self.namespaces:
-            self.namespaces["search_and_filter"] = Search_and_filter(self)
-        return self.namespaces["search_and_filter"]
-    
+        return Search_and_filter(self)
+
     def data(self) -> Search_and_filter:
         """
         Shorter alias for Search_and_Filter
         :return Search_and_filter
         """
-        if "search_and_filter" not in self.namespaces:
-            self.namespaces["search_and_filter"] = Search_and_filter(self)
-        return self.namespaces["search_and_filter"]
+        return Search_and_filter(self)
 
     def table(self) -> Table:
         """
         Table Namespace
         :return Table
         """
-        if "table" not in self.namespaces:
-            self.namespaces["table"] = Table(self)
-        return self.namespaces["table"]
+        return Table(self)

--- a/xata/helpers.py
+++ b/xata/helpers.py
@@ -19,9 +19,8 @@
 
 import logging
 import time
-from datetime import datetime
-from threading import Lock, Thread
 from datetime import datetime, timezone
+from threading import Lock, Thread
 
 from .client import XataClient
 
@@ -276,7 +275,7 @@ class BulkProcessor(object):
                 return sum([len(self.store[n]["records"]) for n in self.store.keys()])
 
 
-def to_rfc339(dt: datetime, tz = timezone.utc) -> str:
+def to_rfc339(dt: datetime, tz=timezone.utc) -> str:
     """
     Format a datetime object to an RFC3339 compliant string
     :link https://xata.io/docs/concepts/data-model#datetime


### PR DESCRIPTION
The lazy loading approach as is in the SDK produced negative side effects, as e.g. you could not use two instances of the client in one script. The concept is abolished for now until a better solution is found.