### PR TITLE
Missing parameter for .xatarc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Xata
+.xatarc
+
 # Distribution / packaging
 .Python
 build/

--- a/xata/client.py
+++ b/xata/client.py
@@ -243,7 +243,7 @@ class XataClient:
     def get_database_name_if_configured(self) -> str:
         self.ensure_config_read()
         if self.config is not None and self.config.get("databaseURL"):
-            _, _, db_name, _ = self._parse_database_url(self.config.get("databaseURL"))
+            _, _, db_name, _, _ = self._parse_database_url(self.config.get("databaseURL"))
             return db_name
         return None
 


### PR DESCRIPTION
Bug fix for using the `.xatarc` file for the `databaseURL`.