### PR TITLE
Mark endpoints as experimental if indicated in the spec

### DIFF
--- a/codegen/generator.py
+++ b/codegen/generator.py
@@ -200,6 +200,12 @@ def generate_endpoint(path: str, method: str, endpoint: dict, parameters: list, 
         operation_id = API_RENAMING[namespace][operation_id]["name"]
         logging.debug("replacing name from %s.%s to %s." % (namespace, endpoint["operationId"].strip(), operation_id))
 
+    # status of the API
+    status = "GA"
+    if "x-experimental" in endpoint:
+        status = "experimental"
+
+    # template variables
     vars = {
         "template": template_ref,
         "operation_id": operation_id,
@@ -207,6 +213,7 @@ def generate_endpoint(path: str, method: str, endpoint: dict, parameters: list, 
         "http_method": method.upper(),
         "path": path,
         "params": endpoint_params,
+        "status": status,
     }
 
     SCHEMA_OUT["endpoints"].append(
@@ -219,12 +226,15 @@ def generate_endpoint(path: str, method: str, endpoint: dict, parameters: list, 
             "method": vars["http_method"],
             "url_path": path,
             "responses": endpoint_params["response_codes"],
+            "status": status,
             "parameters": [
                 {"name": p["name"], "description": p["description"], "in": p["in"], "required": p["required"]}
                 for p in list(endpoint_params["list"])
             ],
         }
     )
+
+    # render template
     template_path = "codegen/templates/%s.tpl" % vars["template"]
     return Template(filename=template_path, output_encoding="utf-8").render(**vars)
 

--- a/codegen/templates/endpoint.tpl
+++ b/codegen/templates/endpoint.tpl
@@ -11,6 +11,9 @@
 
        Path: ${path}
        Method: ${http_method}
+       % if status == "experimental":
+       Status: Experimental
+       % endif
        Response status codes:
        % for rc in params['response_codes']:
        - ${rc["code"]}: ${rc["description"]}

--- a/xata/api/records.py
+++ b/xata/api/records.py
@@ -299,6 +299,7 @@ class Records(Namespace):
 
         Path: /db/{db_branch_name}/tables/{table_name}/bulk
         Method: POST
+        Status: Experimental
         Response status codes:
         - 200: OK
         - 400: Response with multiple errors of the bulk execution


### PR DESCRIPTION
If the OAS has `x-experimental` as status, indicate it in the endpoint doc block.