### PR TITLE
Streaming response

### DIFF
--- a/codegen/api-rename-mapping.json
+++ b/codegen/api-rename-mapping.json
@@ -11,6 +11,10 @@
       "deleteUserAPIKey": {
         "template": "endpoint",
         "name": "delete_user_api_keys"
+      },
+      "getUserOAuthClients": {
+        "template": "endpoint",
+        "name": "get_oauth_user_clients"
       }
     },
     "databases": {

--- a/codegen/templates/data_ask.tpl
+++ b/codegen/templates/data_ask.tpl
@@ -38,4 +38,4 @@
             "content-type": "application/json",
             "accept": "text/event-stream" if streaming_results else "application/json",
         }
-        return self.request("POST", url_path, headers, payload)
+        return self.request("POST", url_path, headers, payload, is_streaming=streaming_results)

--- a/codegen/templates/data_ask_follow_up.tpl
+++ b/codegen/templates/data_ask_follow_up.tpl
@@ -35,4 +35,4 @@
             "content-type": "application/json",
             "accept": "text/event-stream" if streaming_results else "application/json",
         }
-        return self.request("POST", url_path, headers, payload)
+        return self.request("POST", url_path, headers, payload, is_streaming=streaming_results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xata"
-version = "1.0.0a6"
+version = "1.0.0a7"
 description = "Python client for Xata.io"
 authors = ["Xata <support@xata.io>"]
 license = "Apache-2.0"

--- a/tests/integration-tests/search_and_filter_ask_table_test.py
+++ b/tests/integration-tests/search_and_filter_ask_table_test.py
@@ -90,7 +90,7 @@ class TestSearchAndFilterAskTableEndpoint(object):
         assert answer.is_success()
 
         assert "transfer-encoding" in answer.headers
-        assert answer.headers.get('transfer-encoding') == "chunked"
+        assert answer.headers.get("transfer-encoding") == "chunked"
 
     def test_ask_follow_up_question(self):
         first_answer = self.client.data().ask("xata", "does xata have a python sdk")

--- a/tests/integration-tests/search_and_filter_ask_table_test.py
+++ b/tests/integration-tests/search_and_filter_ask_table_test.py
@@ -89,19 +89,8 @@ class TestSearchAndFilterAskTableEndpoint(object):
         answer = self.client.data().ask("xata", "does the data model have link type?", streaming_results=True)
         assert answer.is_success()
 
-        # TODO
-        # use stream=True in namespace.request
-
-        # assert "answer" in answer
-        # assert "records" in answer
-        # assert "sessionId" in answer
-
-        # assert answer["answer"] is not None
-        # assert answer["sessionId"] is not None
-        # assert len(answer["records"]) > 0
-
-        # assert answer.headers["content-type"].lower().startswith("text/event-stream")
-        assert True
+        assert "transfer-encoding" in answer.headers
+        assert answer.headers.get('transfer-encoding') == "chunked"
 
     def test_ask_follow_up_question(self):
         first_answer = self.client.data().ask("xata", "does xata have a python sdk")

--- a/xata/api/authentication.py
+++ b/xata/api/authentication.py
@@ -94,3 +94,24 @@ class Authentication(ApiRequest):
         """
         url_path = f"/user/keys/{key_name}"
         return self.request("DELETE", url_path)
+
+    def get_oauth_user_clients(self) -> ApiResponse:
+        """
+        Retrieve the list of OAuth Clients that a user has authorized
+
+        Reference: https://xata.io/docs/api-reference/user/oauth/clients#get-the-list-of-user-oauth-clients
+        Path: /user/oauth/clients
+        Method: GET
+        Response status codes:
+        - 200: OK
+        - 400: Bad Request
+        - 401: Authentication Error
+        - 404: Example response
+        - 5XX: Unexpected Error
+        Response: application/json
+
+
+        :returns ApiResponse
+        """
+        url_path = "/user/oauth/clients"
+        return self.request("GET", url_path)

--- a/xata/api/search_and_filter.py
+++ b/xata/api/search_and_filter.py
@@ -372,7 +372,7 @@ class SearchAndFilter(ApiRequest):
             "content-type": "application/json",
             "accept": "text/event-stream" if streaming_results else "application/json",
         }
-        return self.request("POST", url_path, headers, payload)
+        return self.request("POST", url_path, headers, payload, is_streaming=streaming_results)
 
     def ask_follow_up(
         self,
@@ -419,7 +419,7 @@ class SearchAndFilter(ApiRequest):
             "content-type": "application/json",
             "accept": "text/event-stream" if streaming_results else "application/json",
         }
-        return self.request("POST", url_path, headers, payload)
+        return self.request("POST", url_path, headers, payload, is_streaming=streaming_results)
 
     def summarize(self, table_name: str, payload: dict, db_name: str = None, branch_name: str = None) -> ApiResponse:
         """

--- a/xata/client.py
+++ b/xata/client.py
@@ -38,7 +38,7 @@ from .api.workspaces import Workspaces
 
 # TODO this is a manual task, to keep in sync with pyproject.toml
 # could/should be automated to keep in sync
-__version__ = "1.0.0a6"
+__version__ = "1.0.0a7"
 
 PERSONAL_API_KEY_LOCATION = "~/.config/xata/key"
 DEFAULT_DATA_PLANE_DOMAIN = "xata.sh"


### PR DESCRIPTION
- make the response streaming for `ask` and `ask_follow_up` endpoints
- use Session for connection reuse
- set 1.0.0a7 version numbers
- new endpoint `get_oauth_user_clients`
- safer way to handle sessions and not to exhaust the connection pool