### PR TITLE
Make `x-xata-agent` consistent with ts libary

### DIFF
--- a/tests/unit-tests/client_telemetry_test.py
+++ b/tests/unit-tests/client_telemetry_test.py
@@ -36,7 +36,7 @@ class TestClientTelemetry(unittest.TestCase):
         assert utils.PATTERNS_UUID4.match(headers1["x-xata-session-id"])
         assert headers1["x-xata-client-id"] != headers1["x-xata-session-id"]
         assert "x-xata-agent" in headers1
-        assert headers1["x-xata-agent"] == f"client=PY_SDK;version={__version__};"
+        assert headers1["x-xata-agent"] == f"client=PY_SDK; version={__version__}"
 
         api_key = "this-key-42"
         client2 = XataClient(api_key=api_key, workspace_id="ws_id")

--- a/xata/client.py
+++ b/xata/client.py
@@ -127,7 +127,7 @@ class XataClient:
             "connection": "keep-alive",
             "x-xata-client-id": str(uuid.uuid4()),
             "x-xata-session-id": str(uuid.uuid4()),
-            "x-xata-agent": f"client=PY_SDK;version={__version__};",
+            "x-xata-agent": f"client=PY_SDK; version={__version__}",
         }
 
         # init namespaces

--- a/xata/client.py
+++ b/xata/client.py
@@ -127,6 +127,7 @@ class XataClient:
             "connection": "keep-alive",
             "x-xata-client-id": str(uuid.uuid4()),
             "x-xata-session-id": str(uuid.uuid4()),
+            # the format is key1=value; key2=value (with spaces and no trailing ;)
             "x-xata-agent": f"client=PY_SDK; version={__version__}",
         }
 

--- a/xata/helpers.py
+++ b/xata/helpers.py
@@ -77,7 +77,7 @@ class BulkProcessor(object):
             raise Exception("batch size can not be less than one, default: %d" % BP_DEFAULT_BATCH_SIZE)
 
         self.client = client
-        telemetry = "%shelper=bp;v=%s" % (self.client.get_headers()["x-xata-agent"], BP_VERSION)
+        telemetry = "%s; helper=bp; v=%s" % (self.client.get_headers()["x-xata-agent"], BP_VERSION)
         self.client.set_header("x-xata-agent", telemetry)
 
         self.processing_timeout = processing_timeout

--- a/xata/helpers.py
+++ b/xata/helpers.py
@@ -77,7 +77,7 @@ class BulkProcessor(object):
             raise Exception("batch size can not be less than one, default: %d" % BP_DEFAULT_BATCH_SIZE)
 
         self.client = client
-        telemetry = "%s; helper=bp; v=%s" % (self.client.get_headers()["x-xata-agent"], BP_VERSION)
+        telemetry = "%s; helper=bp:%s" % (self.client.get_headers()["x-xata-agent"], BP_VERSION)
         self.client.set_header("x-xata-agent", telemetry)
 
         self.processing_timeout = processing_timeout
@@ -321,7 +321,7 @@ class Transaction(object):
         :param client: XataClient
         """
         self.client = client
-        telemetry = "%shelper=trx;v=%s" % (self.client.get_headers()["x-xata-agent"], TRX_VERSION)
+        telemetry = "%s; helper=trx:%s" % (self.client.get_headers()["x-xata-agent"], TRX_VERSION)
         self.client.set_header("x-xata-agent", telemetry)
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 


### PR DESCRIPTION
cc: @deverts 

Added a space, removed trailing `;`

![Screenshot 2023-11-03 at 12 15 32](https://github.com/xataio/xata-py/assets/6640874/10f4857d-f2da-4222-8e18-10b314ddcb11)

![Screenshot 2023-11-03 at 12 15 24](https://github.com/xataio/xata-py/assets/6640874/6685bdba-bb62-4038-bd06-03a07b3dd877)
