### PR TITLE
Add error message property

### DIFF
--- a/tests/integration-tests/api_response_test.py
+++ b/tests/integration-tests/api_response_test.py
@@ -84,3 +84,16 @@ class TestApiResponse(object):
         assert posts.is_success()
         assert len(posts["records"]) == 1
         assert not posts.has_more_results()
+
+    def test_error_message(self):
+        user = self.client.records().get("Nope", "nope^2")
+        assert not user.is_success()
+        assert user.status_code > 299
+        assert user.error_message is not None
+        assert user.error_message.endswith("not found")
+
+    def test_error_message_should_not_be_set(self):
+        user = self.client.users().get()
+        assert user.is_success()
+        assert user.status_code < 300
+        assert not user.error_message

--- a/xata/api_response.py
+++ b/xata/api_response.py
@@ -42,7 +42,9 @@ class ApiResponse(dict):
 
     def server_message(self) -> Union[str, None]:
         """
-        Get the server message from the response
+        Get the server message from the response, if you need the error message
+        please the property error_message. This channel is only relevant for
+        deprecation messages or other meta information from Xata
         :returns str | None
         """
         return self.headers["x-xata-message"] if "x-xata-message" in self.headers else None
@@ -95,7 +97,7 @@ class ApiResponse(dict):
         return self.response.status_code
     
     @property
-    def error_message(self) -> str | None:
+    def error_message(self) -> Union[str, None]:
         """
         Get the error message if it is set, otherwise None
         :returns str | None

--- a/xata/api_response.py
+++ b/xata/api_response.py
@@ -44,7 +44,7 @@ class ApiResponse(dict):
         """
         Get the server message from the response, if you need the error message
         please the property error_message. This channel is only relevant for
-        deprecation messages or other meta information from Xata
+        deprecation messages or other meta information from Xata.
         :returns str | None
         """
         return self.headers["x-xata-message"] if "x-xata-message" in self.headers else None

--- a/xata/api_response.py
+++ b/xata/api_response.py
@@ -93,6 +93,16 @@ class ApiResponse(dict):
         :returns int
         """
         return self.response.status_code
+    
+    @property
+    def error_message(self) -> str | None:
+        """
+        Get the error message if it is set, otherwise None
+        :returns str | None
+        """
+        if self.status_code < 300:
+            return None
+        return self.response.json().get("message", None)
 
     @property
     def headers(self) -> dict:


### PR DESCRIPTION
add more clarity to distinguish between the meta channel and error messages from the server.