### PR TITLE
Reworked tests to support running on specific database

### DIFF
--- a/tests/integration-tests/branch_test.py
+++ b/tests/integration-tests/branch_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import pytest
 import utils
 
@@ -29,28 +31,15 @@ class TestBranchNamespace(object):
         self.branch_name = "main"
         self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
 
-        # create database
-        assert self.client.databases().create(self.db_name).is_success()
-        assert self.client.table().create("Posts").is_success
-        assert (
-            self.client.table()
-            .set_schema(
-                "Posts",
-                {
-                    "columns": [
-                        {"name": "title", "type": "string"},
-                        {"name": "labels", "type": "multiple"},
-                        {"name": "slug", "type": "string"},
-                        {"name": "text", "type": "text"},
-                    ]
-                },
-            )
-            .is_success()
-        )
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
+        assert self.client.table().create("Posts").is_success()
+        assert self.client.table().set_schema("Posts", utils.get_posts_schema()).is_success()
 
     def teardown_class(self):
-        r = self.client.databases().delete(self.db_name)
-        assert r.is_success()
+        assert self.client.table().delete("Posts").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_get_branch_list(self):
         r = self.client.branch().list(self.db_name)

--- a/tests/integration-tests/databases_test.py
+++ b/tests/integration-tests/databases_test.py
@@ -26,7 +26,7 @@ from xata.errors import UnauthorizedError
 
 class TestDatabasesNamespace(object):
     def setup_class(self):
-        self.db_name = utils.get_db_name()
+        self.db_name = utils.get_db_name(True)
         self.branch_name = "main"
         self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
 

--- a/tests/integration-tests/files_access.py
+++ b/tests/integration-tests/files_access.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+import os
 import time
 
 import utils
@@ -28,25 +29,18 @@ from xata.client import XataClient
 class TestFilesAccess(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
-        self.branch_name = "main"
-        self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
+        self.client = XataClient(db_name=self.db_name)
         self.fake = utils.get_faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Attachments").is_success()
-        assert (
-            self.client.table()
-            .set_schema(
-                "Attachments",
-                utils.get_attachments_schema(),
-                db_name=self.db_name,
-                branch_name=self.branch_name,
-            )
-            .is_success()
-        )
+        assert self.client.table().set_schema("Attachments", utils.get_attachments_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Attachments").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_public_flag_true(self):
         payload = {

--- a/tests/integration-tests/files_multiple_files_test.py
+++ b/tests/integration-tests/files_multiple_files_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import utils
 from requests import request
 
@@ -26,25 +28,18 @@ from xata.client import XataClient
 class TestFilesMultipleFiles(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
-        self.branch_name = "main"
-        self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
+        self.client = XataClient(db_name=self.db_name)
         self.fake = utils.get_faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Attachments").is_success()
-        assert (
-            self.client.table()
-            .set_schema(
-                "Attachments",
-                utils.get_attachments_schema(),
-                db_name=self.db_name,
-                branch_name=self.branch_name,
-            )
-            .is_success()
-        )
+        assert self.client.table().set_schema("Attachments", utils.get_attachments_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Attachments").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_put_file_item(self):
         payload = {

--- a/tests/integration-tests/files_single_file_test.py
+++ b/tests/integration-tests/files_single_file_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import utils
 from faker import Faker
 
@@ -26,25 +28,18 @@ from xata.client import XataClient
 class TestFilesSingleFile(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
-        self.branch_name = "main"
-        self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
-        self.fake = Faker()
+        self.client = XataClient(db_name=self.db_name)
+        self.fake = utils.get_faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Attachments").is_success()
-        assert (
-            self.client.table()
-            .set_schema(
-                "Attachments",
-                utils.get_attachments_schema(),
-                db_name=self.db_name,
-                branch_name=self.branch_name,
-            )
-            .is_success()
-        )
+        assert self.client.table().set_schema("Attachments", utils.get_attachments_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Attachments").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_put_csv_file(self):
         payload = {"title": self.fake.catch_phrase()}

--- a/tests/integration-tests/files_transormations_test.py
+++ b/tests/integration-tests/files_transormations_test.py
@@ -19,6 +19,7 @@
 
 import io
 import json
+import os
 
 import pytest
 import utils
@@ -33,22 +34,17 @@ class TestFilesTransformations(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
         self.client = XataClient(db_name=self.db_name)
-        self.fake = Faker()
+        self.fake = utils.get_faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Attachments").is_success()
-        assert (
-            self.client.table()
-            .set_schema(
-                "Attachments",
-                utils.get_attachments_schema(),
-                db_name=self.db_name,
-            )
-            .is_success()
-        )
+        assert self.client.table().set_schema("Attachments", utils.get_attachments_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Attachments").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_rotate_public_file(self):
         payload = {

--- a/tests/integration-tests/files_upload_url_test.py
+++ b/tests/integration-tests/files_upload_url_test.py
@@ -17,33 +17,29 @@
 # under the License.
 #
 
-import utils
+import os
 
+import utils
 from requests import request
+
 from xata.client import XataClient
+
 
 class TestFilesSingleFile(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
-        self.branch_name = "main"
-        self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
+        self.client = XataClient(db_name=self.db_name)
         self.fake = utils.get_faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Attachments").is_success()
-        assert (
-            self.client.table()
-            .set_schema(
-                "Attachments",
-                utils.get_attachments_schema(),
-                db_name=self.db_name,
-                branch_name=self.branch_name,
-            )
-            .is_success()
-        )
+        assert self.client.table().set_schema("Attachments", utils.get_attachments_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Attachments").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_upload_file(self):
         payload = {"title": self.fake.catch_phrase()}

--- a/tests/integration-tests/helpers_bulkprocessor_test.py
+++ b/tests/integration-tests/helpers_bulkprocessor_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import pytest
 import utils
 from faker import Faker
@@ -31,24 +33,13 @@ class TestHelpersBulkProcessor(object):
         self.client = XataClient(db_name=self.db_name)
         self.fake = Faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Posts").is_success()
+        assert self.client.table().set_schema("Posts", utils.get_posts_schema()).is_success()
         assert self.client.table().create("Users").is_success()
 
         # create schema
-        assert (
-            self.client.table()
-            .set_schema(
-                "Posts",
-                {
-                    "columns": [
-                        {"name": "title", "type": "string"},
-                        {"name": "text", "type": "text"},
-                    ]
-                },
-            )
-            .is_success()
-        )
         assert (
             self.client.table()
             .set_schema(
@@ -64,7 +55,10 @@ class TestHelpersBulkProcessor(object):
         )
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Posts").is_success()
+        assert self.client.table().delete("Users").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     @pytest.fixture
     def record(self) -> dict:

--- a/tests/integration-tests/helpers_transaction_test.py
+++ b/tests/integration-tests/helpers_transaction_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import pytest
 import utils
 from faker import Faker
@@ -28,29 +30,18 @@ from xata.helpers import Transaction
 class TestHelpersTransaction(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
-        self.branch_name = "main"
-        self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
+        self.client = XataClient(db_name=self.db_name)
         self.fake = Faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Posts").is_success()
-        assert (
-            self.client.table()
-            .set_schema(
-                "Posts",
-                {
-                    "columns": [
-                        {"name": "title", "type": "string"},
-                        {"name": "content", "type": "text"},
-                    ]
-                },
-            )
-            .is_success()
-        )
+        assert self.client.table().set_schema("Posts", utils.get_posts_schema()).is_success()
 
     def teardown_class(self):
-        r = self.client.databases().delete(self.db_name)
-        assert r.is_success()
+        assert self.client.table().delete("Posts").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     @pytest.fixture
     def record(self) -> dict:

--- a/tests/integration-tests/records_branch_transactions_test.py
+++ b/tests/integration-tests/records_branch_transactions_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import pytest
 import utils
 
@@ -35,12 +37,15 @@ class TestRecordsBranchTransactionsNamespace(object):
         self.record_ids = []
         self.fake = utils.get_faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Posts").is_success()
         assert self.client.table().set_schema("Posts", utils.get_posts_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Posts").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_insert_only(self):
         payload = {

--- a/tests/integration-tests/records_file_operations_test.py
+++ b/tests/integration-tests/records_file_operations_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import utils
 
 from xata.client import XataClient
@@ -28,20 +30,15 @@ class TestRecordsFileOperations(object):
         self.client = XataClient(db_name=self.db_name)
         self.fake = utils.get_faker()
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Attachments").is_success()
-        assert (
-            self.client.table()
-            .set_schema(
-                "Attachments",
-                utils.get_attachments_schema(),
-                db_name=self.db_name,
-            )
-            .is_success()
-        )
+        assert self.client.table().set_schema("Attachments", utils.get_attachments_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Attachments").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_insert_record_with_files_and_read_it(self):
         payload = {

--- a/tests/integration-tests/records_test.py
+++ b/tests/integration-tests/records_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import pytest
 import utils
 
@@ -30,12 +32,15 @@ class TestRecordsNamespace(object):
         self.fake = utils.get_faker()
         self.record_id = utils.get_random_string(24)
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Posts").is_success()
         assert self.client.table().set_schema("Posts", utils.get_posts_schema()).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Posts").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     @pytest.fixture
     def record(self) -> dict:

--- a/tests/integration-tests/search_and_filter_query_test.py
+++ b/tests/integration-tests/search_and_filter_query_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import utils
 from faker import Faker
 
@@ -35,14 +37,17 @@ class TestSearchAndFilterQueryApi(object):
         self.posts = utils.get_posts(50)
         self.client = XataClient(db_name=self.db_name)
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("Posts").is_success()
         assert self.client.table().set_schema("Posts", utils.get_posts_schema()).is_success()
         assert self.client.records().bulk_insert("Posts", {"records": self.posts}).is_success()
         utils.wait_until_records_are_indexed("Posts", "title", self.client)
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Posts").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_query_table(self):
         payload = {

--- a/tests/integration-tests/search_and_filter_revlinks_test.py
+++ b/tests/integration-tests/search_and_filter_revlinks_test.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+import os
 import random
 
 import utils
@@ -32,7 +33,8 @@ class TestSearchAndFilterRevLinks(object):
         self.record_id = utils.get_random_string(24)
         self.client = XataClient(db_name=self.db_name)
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
 
         assert self.client.table().create("Users").is_success()
         assert self.client.table().create("Posts").is_success()
@@ -80,7 +82,10 @@ class TestSearchAndFilterRevLinks(object):
         assert self.client.records().bulk_insert("Posts", {"records": self.posts}).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Posts").is_success()
+        assert self.client.table().delete("Users").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_revlinks_with_alias(self):
         payload = {

--- a/tests/integration-tests/search_and_filter_vector_search_test.py
+++ b/tests/integration-tests/search_and_filter_vector_search_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import utils
 
 from xata.client import XataClient
@@ -32,7 +34,8 @@ class TestSearchAndFilterVectorSearchEndpoint(object):
         self.branch_name = "main"
         self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
         assert self.client.table().create("users").is_success()
 
         # create schema
@@ -63,7 +66,9 @@ class TestSearchAndFilterVectorSearchEndpoint(object):
         utils.wait_until_records_are_indexed("users", "full_name", self.client)
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("users").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_vector_search_table_simple(self):
         payload = {

--- a/tests/integration-tests/sql_query_test.py
+++ b/tests/integration-tests/sql_query_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import utils
 
 from xata.client import XataClient
@@ -26,7 +28,10 @@ class TestSqlQuery(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
         self.client = XataClient(db_name=self.db_name)
-        assert self.client.databases().create(self.db_name).is_success()
+
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
+
         assert self.client.table().create("Users").is_success()
         assert (
             self.client.table()
@@ -46,7 +51,9 @@ class TestSqlQuery(object):
         assert self.client.records().bulk_insert("Users", {"records": users}).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Users").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_query(self):
         r = self.client.sql().query('SELECT * FROM "Users" LIMIT 5')

--- a/tests/integration-tests/table_test.py
+++ b/tests/integration-tests/table_test.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+import os
+
 import pytest
 import utils
 
@@ -26,13 +28,14 @@ from xata.client import XataClient
 class TestTableNamespace(object):
     def setup_class(self):
         self.db_name = utils.get_db_name()
-        self.branch_name = "main"
-        self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
+        self.client = XataClient(db_name=self.db_name)
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     @pytest.fixture
     def columns(self) -> dict:
@@ -63,8 +66,7 @@ class TestTableNamespace(object):
         r = self.client.table().update(
             "RenameMe",
             {"name": "NewName"},
-            db_name=self.db_name,
-            branch_name=self.branch_name,
+            db_name=self.db_name
         )
         assert r.is_success()
         assert r["status"] == "completed"

--- a/tests/integration-tests/type_json_test.py
+++ b/tests/integration-tests/type_json_test.py
@@ -18,6 +18,7 @@
 #
 
 import json
+import os
 
 import utils
 from faker import Faker
@@ -32,10 +33,13 @@ class TestJsonColumnType(object):
         self.record_id = utils.get_random_string(24)
         self.client = XataClient(db_name=self.db_name)
 
-        assert self.client.databases().create(self.db_name).is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().create(self.db_name).is_success()
 
     def teardown_class(self):
-        assert self.client.databases().delete(self.db_name).is_success()
+        assert self.client.table().delete("Posts").is_success()
+        if not os.environ.get("XATA_STATIC_DB_NAME"):
+            assert self.client.databases().delete(self.db_name).is_success()
 
     def test_create_table_with_type(self):
         assert self.client.table().create("Posts").is_success()

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -29,15 +29,18 @@ from faker import Faker
 from xata.client import XataClient
 
 faker = Faker()
-#Faker.seed(412)
+# Faker.seed(412)
 
 
 def get_faker() -> Faker:
     return faker
 
 
-def get_db_name() -> str:
-    return f"sdk-integration-py-{get_random_string(6)}"
+def get_db_name(always_random: bool = False) -> str:
+    generated_name = f"sdk-integration-py-{get_random_string(6)}"
+    if always_random:
+        return generated_name
+    return os.environ.get("XATA_STATIC_DB_NAME", generated_name)
 
 
 def wait_until_records_are_indexed(table: str, col: str, client: XataClient):
@@ -115,5 +118,6 @@ def get_posts_schema() -> dict:
             {"name": "labels", "type": "multiple"},
             {"name": "slug", "type": "string"},
             {"name": "content", "type": "text"},
+            {"name": "text", "type": "text"}
         ]
     }

--- a/tests/integration-tests/workspaces_test.py
+++ b/tests/integration-tests/workspaces_test.py
@@ -25,9 +25,8 @@ from xata.client import XataClient
 
 class TestWorkspacesNamespace(object):
     def setup_class(self):
-        self.db_name = utils.get_db_name()
-        self.branch_name = "main"
-        self.client = XataClient(db_name=self.db_name, branch_name=self.branch_name)
+        self.db_name = utils.get_db_name(True)
+        self.client = XataClient(db_name=self.db_name)
         self.workspace_name = "py-sdk-tests-%s" % utils.get_random_string(6)
 
     def test_list_workspaces(self):


### PR DESCRIPTION
- only run tests on the database passed via `XATA_STATIC_DB_NAME`
- add extra step in action to run the static db as well